### PR TITLE
new(cmd): add `--loop` option to run command

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -79,7 +79,7 @@ func Execute() {
 	}
 }
 
-// WithSignals returns a copy of ctx  a new context.
+// WithSignals returns a copy of ctx with a new Done channel.
 // The returned context's Done channel is closed when a SIGKILL or SIGTERM signal is received.
 func WithSignals(ctx context.Context) context.Context {
 	sigCh := make(chan os.Signal, 1)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -47,8 +47,8 @@ Warning:
 	ns.DefValue = DefaultNamespace
 	ns.Value.Set(DefaultNamespace)
 
-	var sleep time.Duration
-	flags.DurationVar(&sleep, "sleep", 0, "Time to sleep prior to trigger an action")
+	sleep := time.Second
+	flags.DurationVar(&sleep, "sleep", sleep, "The length of time to wait before running an action. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means no sleep.")
 
 	var loop bool
 	flags.BoolVar(&loop, "loop", false, "Run in a loop")

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -48,7 +48,10 @@ Warning:
 	ns.Value.Set(DefaultNamespace)
 
 	var sleep time.Duration
-	flags.DurationVar(&sleep, "sleep", 0, "time to sleep prior to trigger an action")
+	flags.DurationVar(&sleep, "sleep", 0, "Time to sleep prior to trigger an action")
+
+	var loop bool
+	flags.BoolVar(&loop, "loop", false, "Run in a loop")
 
 	c.RunE = func(c *cobra.Command, args []string) error {
 		ns, err := flags.GetString("namespace")
@@ -58,11 +61,13 @@ Warning:
 		l := logger.StandardLogger()
 
 		r, err := runner.New(
+			runner.WithContext(c.Context()),
 			runner.WithLogger(l),
 			runner.WithKubeFactory(cmdutil.NewFactory(matchVersionKubeConfigFlags)),
 			runner.WithKubeNamespace(ns),
 			runner.WithExecutable("", "--loglevel", l.GetLevel().String(), "run"),
 			runner.WithSleep(sleep),
+			runner.WithLoop(loop),
 		)
 		if err != nil {
 			return err

--- a/docs/event-generator.md
+++ b/docs/event-generator.md
@@ -13,9 +13,9 @@ event-generator [flags]
 ### Options
 
 ```
-  -c, --config string     config file path (default $HOME/.falco-event-generator.yaml if exists)
+  -c, --config string     Config file path (default $HOME/.falco-event-generator.yaml if exists)
   -h, --help              help for event-generator
-  -l, --loglevel string   log level (default "info")
+  -l, --loglevel string   Log level (default "info")
 ```
 
 ### SEE ALSO

--- a/docs/event-generator_list.md
+++ b/docs/event-generator_list.md
@@ -20,8 +20,8 @@ event-generator list [regexp] [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string     config file path (default $HOME/.falco-event-generator.yaml if exists)
-  -l, --loglevel string   log level (default "info")
+  -c, --config string     Config file path (default $HOME/.falco-event-generator.yaml if exists)
+  -l, --loglevel string   Log level (default "info")
 ```
 
 ### SEE ALSO

--- a/docs/event-generator_run.md
+++ b/docs/event-generator_run.md
@@ -31,11 +31,12 @@ event-generator run [regexp] [flags]
   -h, --help                           help for run
       --insecure-skip-tls-verify       If true, the server's certificate will not be checked for validity. This will make your HTTPS connections insecure
       --kubeconfig string              Path to the kubeconfig file to use for CLI requests.
+      --loop                           Run in a loop
       --match-server-version           Require server version to match client version
   -n, --namespace string               If present, the namespace scope for this CLI request (default "default")
       --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
   -s, --server string                  The address and port of the Kubernetes API server
-      --sleep duration                 time to sleep prior to trigger an action
+      --sleep duration                 Time to sleep prior to trigger an action
       --token string                   Bearer token for authentication to the API server
       --user string                    The name of the kubeconfig user to use
 ```
@@ -43,8 +44,8 @@ event-generator run [regexp] [flags]
 ### Options inherited from parent commands
 
 ```
-  -c, --config string     config file path (default $HOME/.falco-event-generator.yaml if exists)
-  -l, --loglevel string   log level (default "info")
+  -c, --config string     Config file path (default $HOME/.falco-event-generator.yaml if exists)
+  -l, --loglevel string   Log level (default "info")
 ```
 
 ### SEE ALSO

--- a/docs/event-generator_run.md
+++ b/docs/event-generator_run.md
@@ -36,7 +36,7 @@ event-generator run [regexp] [flags]
   -n, --namespace string               If present, the namespace scope for this CLI request (default "default")
       --request-timeout string         The length of time to wait before giving up on a single server request. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means don't timeout requests. (default "0")
   -s, --server string                  The address and port of the Kubernetes API server
-      --sleep duration                 Time to sleep prior to trigger an action
+      --sleep duration                 The length of time to wait before running an action. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means no sleep. (default 1s)
       --token string                   Bearer token for authentication to the API server
       --user string                    The name of the kubeconfig user to use
 ```


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note: it's really useful for the changelog!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

/kind documentation

> /kind tests

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area commands

/area pkg

> /area events

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:
This PR implements the `--loop` option for the run command and SIGTERM/SIGINT signals handling for graceful shutdown.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #6 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
new(cmd): add `--loop` option to run command
update(cmd): sleep time default to 1s
```