### PR TITLE
fix(Makefile): correct `make test` when no bundle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ clean:
 	$(RM) -R ${output} ${docgen}
 
 .PHONY: test
-test:
+test: events/k8saudit/yaml/bundle.go
 	$(GO) vet ./...
 	$(GO) test ${TEST_FLAGS} ./...
 


### PR DESCRIPTION
Signed-off-by: Leonardo Grasso <me@leonardograsso.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note: it's really useful for the changelog!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind documentation

> /kind tests

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area commands

> /area pkg

> /area events

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:
This PR fixes `make test` when no bundle file (`events/k8saudit/yaml_loader.go`) is present.

The [issue](https://app.circleci.com/pipelines/github/falcosecurity/event-generator/1/workflows/65dd6a96-857c-4b2e-98b9-f7a214c778e6/jobs/1/parallel-runs/0/steps/0-102) showed up on CircleCI.


**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
NONE
```