### PR TITLE
fix(syscall): isolate NonSudoSetuid in a child process

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -66,6 +66,7 @@ Warning:
 			runner.WithLogger(l),
 			runner.WithKubeFactory(cmdutil.NewFactory(matchVersionKubeConfigFlags)),
 			runner.WithKubeNamespace(ns),
+			// todo(leogr): inherit other flags
 			runner.WithExecutable("", "--loglevel", l.GetLevel().String(), "run"),
 			runner.WithSleep(sleep),
 			runner.WithLoop(loop),

--- a/events/interfaces.go
+++ b/events/interfaces.go
@@ -22,9 +22,12 @@ type Helper interface {
 	// first called order.
 	Cleanup(f func(), args ...interface{})
 
-	// SpawnAs respawns the process as name and run another action.
-	// An action must not spawn itself to avoid an infinite loop.
+	// SpawnAs starts a child process and waits for it to complete.
+	// The child runs the given action as a different program name.
 	SpawnAs(name string, action string, args ...string) error
+
+	// Spawned returns true if the action is running in a child process.
+	Spawned() bool
 
 	// ResourceBuilder returns a k8s' resource.Builder.
 	ResourceBuilder() *resource.Builder

--- a/events/syscall/non_sudo_setuid.go
+++ b/events/syscall/non_sudo_setuid.go
@@ -9,11 +9,15 @@ import (
 var _ = events.Register(NonSudoSetuid)
 
 func NonSudoSetuid(h events.Helper) error {
-	h.Log().Debug("first setuid to something non-root, then try to setuid back to root")
-	if err := becameUser(h, "daemon"); err != nil {
-		return err
+	if h.Spawned() {
+		h.Log().Debug("first setuid to something non-root, then try to setuid back to root")
+		if err := becameUser(h, "daemon"); err != nil {
+			return err
+		}
+		err := becameUser(h, "root")
+		h.Log().WithError(err).Debug("ignore root setuid error")
+		return nil
+	} else {
+		return h.SpawnAs("child", "syscall.NonSudoSetuid")
 	}
-	err := becameUser(h, "root")
-	h.Log().WithError(err).Debug("ignore root setuid error")
-	return nil
 }

--- a/pkg/runner/helper.go
+++ b/pkg/runner/helper.go
@@ -19,11 +19,11 @@ var _ events.Helper = &helper{}
 
 // Helper errors
 var (
-	ErrSelfSpawnAs = errors.New("cannot spawn the same action")
+	ErrChildSpawn = errors.New("cannot re-spawn a child process")
 )
 
 type helper struct {
-	name    string
+	action  string
 	runner  *Runner
 	log     *logger.Entry
 	hasLog  bool
@@ -68,8 +68,8 @@ func (h *helper) Cleanup(f func(), args ...interface{}) {
 func (h *helper) SpawnAs(name string, action string, args ...string) error {
 	fullArgs := append([]string{fmt.Sprintf("^%s$", action)}, args...)
 	h.Log().WithField("args", strings.Join(fullArgs, " ")).Infof(`spawn as "%s"`, name)
-	if name == h.name {
-		return ErrSelfSpawnAs
+	if h.Spawned() {
+		return ErrChildSpawn
 	}
 	tmpDir, err := ioutil.TempDir(os.TempDir(), "falco-event-generator")
 	if err != nil {
@@ -92,4 +92,8 @@ func (h *helper) SpawnAs(name string, action string, args ...string) error {
 	}
 
 	return nil
+}
+
+func (h *helper) Spawned() bool {
+	return h.runner.alias != ""
 }

--- a/pkg/runner/runner.go
+++ b/pkg/runner/runner.go
@@ -38,7 +38,7 @@ func (r *Runner) trigger(n string, f events.Action) (cleanup func(), err error) 
 	log := r.logEntry().WithFields(fields)
 
 	h := &helper{
-		name:   n,
+		action: n,
 		runner: r,
 		log:    log,
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note: it's really useful for the changelog!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind documentation

> /kind tests

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area commands

/area pkg

/area events

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:
Running `syscall.NonSudoSetuid` affects the execution of subsequent actions. We need to isolate it in a child process.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #21 

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release, prepend the string "action required:".
For example, `action required: change the API interface of the rule engine`.
-->

```release-note
fix(events/syscall): NonSudoSetuid affected subsequent actions
```