### PR TITLE
fix: add `build-base` to builder image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16.5-alpine3.13 as builder
+FROM golang:1.16.5-alpine3.14 as builder
 
 LABEL maintainer="cncf-falco-dev@lists.cncf.io"
 
@@ -9,7 +9,7 @@ COPY . .
 
 RUN make
 
-FROM alpine:3.13
+FROM alpine:3.14
 
 COPY --from=builder /event-generator/event-generator /bin/event-generator
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM golang:1.16.5-alpine3.13 as builder
 
 LABEL maintainer="cncf-falco-dev@lists.cncf.io"
 
-RUN apk add --no-cache make bash git
+RUN apk add --no-cache make bash git build-base
 
 WORKDIR /event-generator
 COPY . .


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

**What this PR does / why we need it**:

The `build-base` meta-package is now needed by the builder image since some dependencies make use of `cgo`.
Since https://github.com/falcosecurity/event-generator/pull/48, trying to build the docker image without `build-base` fails with the following error:
```
...
# github.com/falcosecurity/event-generator
/usr/local/go/pkg/tool/linux_amd64/link: running gcc failed: exec: "gcc": executable file not found in $PATH

make: *** [Makefile:30: event-generator] Error 2
```

To reproduce the issue, try `make image` from the master branch.

As a bonus, this PR also upgrades the base image version from alpine 3.13 to 3.14 as well.

/milestone v0.7.0


**Which issue(s) this PR fixes**:



**Special notes for your reviewer**:
