### PR TITLE
feat(pkg/counter): added a DryRun option to avoid connecting to falco gRPC api

### DIFF
--- a/cmd/bench.go
+++ b/cmd/bench.go
@@ -52,6 +52,8 @@ One commmon way to use this command is as following:
 	flags.DurationVar(&pollingTimeout, "polling-interval", time.Millisecond*100, "Duration of gRPC APIs polling timeout")
 	var humanize bool
 	flags.BoolVar(&humanize, "humanize", true, "Humanize values when printing statistics")
+	var dryRun bool
+	flags.BoolVar(&dryRun, "dry-run", false, "Do not connect to Falco gRPC API")
 
 	grpcCfg := grpcFlags(flags)
 
@@ -86,6 +88,7 @@ One commmon way to use this command is as following:
 			counter.WithRoundDuration(roundDuration),
 			counter.WithPollingTimeout(pollingTimeout),
 			counter.WithHumanize(humanize),
+			counter.WithDryRun(dryRun),
 		)
 		if pid != 0 {
 			opts = append(opts, counter.WithPid(pid))

--- a/pkg/counter/stats.go
+++ b/pkg/counter/stats.go
@@ -69,11 +69,13 @@ func (c *Counter) logStats() {
 		lost += s.Ratio
 	}
 
-	lost = 1 - lost/float64(len(c.actions)) // lost average
-	if c.humanize {
-		logStatsEntry = logStatsEntry.WithField("lost", fmt.Sprintf("%d%%", int(lost*100)))
-	} else {
-		logStatsEntry = logStatsEntry.WithField("lost", lost)
+	if !c.dryRun {
+		lost = 1 - lost/float64(len(c.actions)) // lost average
+		if c.humanize {
+			logStatsEntry = logStatsEntry.WithField("lost", fmt.Sprintf("%d%%", int(lost*100)))
+		} else {
+			logStatsEntry = logStatsEntry.WithField("lost", lost)
+		}
 	}
 
 	logStatsEntry.Info("statistics")


### PR DESCRIPTION
```
Signed-off-by: Federico Di Pierro <nierro92@gmail.com>
Co-authored-by: Leonardo Grasso <me@leonardograsso.com>
```

**What type of PR is this?**

/kind feature

**Any specific area of the project related to this PR?**

/area pkg

**What this PR does / why we need it**:
This PR adds a dryrun option that creates events in the system without actually connecting to falco; useful to check the impact of eg: the kmod driver on the system (dryrun normal and with the kmod loaded), and then check impact of adding falco consuming by the driver.

**Which issue(s) this PR fixes**:

Fixes #

**Special notes for your reviewer**:

