### PR TITLE
Release docker images for arm64

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,19 @@ jobs:
       - setup_remote_docker:
           version: 20.10.6
       - run:
+          name: Install Docker Buildx
+          command: |
+            mkdir -vp ~/.docker/cli-plugins/
+            curl --silent -L --output ~/.docker/cli-plugins/docker-buildx https://github.com/docker/buildx/releases/download/v0.3.1/buildx-v0.3.1.linux-amd64
+            chmod a+x ~/.docker/cli-plugins/docker-buildx
+            docker run -it --rm --privileged tonistiigi/binfmt --install all
+      - run:
           name: Prepare env
           command: |
             echo ${DOCKERHUB_SECRET} | docker login -u ${DOCKERHUB_USER} --password-stdin
-      - run: curl -sL https://git.io/goreleaser | bash
+      - run:
+          name: Go releaser
+          no_output_timeout: 40m
+          command: |
+            export DOCKER_CLI_EXPERIMENTAL=enabled
+            curl -sL https://git.io/goreleaser | bash

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -9,19 +9,20 @@ builds:
     goarch:
     - amd64
     - 386
+    - arm64
     main: .
     env:
       - CGO_ENABLED=0
     binary: event-generator
 
 dockers:
-  -
+  - use: buildx
     goos: linux
     goarch: amd64
     dockerfile: Dockerfile
     image_templates:
-      - "falcosecurity/event-generator:latest"
-      - "falcosecurity/event-generator:{{ .Version }}"
+      - "falcosecurity/event-generator:latest-amd64"
+      - "falcosecurity/event-generator:{{ .Version }}-amd64"
     build_flag_templates:
       - "--pull"
       - "--label=org.opencontainers.image.created={{.Date}}"
@@ -38,6 +39,39 @@ dockers:
       - go.sum
       - main.go
       - Makefile
+  - use: buildx
+    goos: linux
+    goarch: arm64
+    dockerfile: Dockerfile
+    image_templates:
+      - "falcosecurity/event-generator:latest-arm64v8"
+      - "falcosecurity/event-generator:{{ .Version }}-arm64v8"
+    build_flag_templates:
+      - "--platform=linux/arm64/v8"
+      - "--pull"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.name={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+    extra_files:
+      - .git
+      - cmd
+      - pkg
+      - events
+      - tools
+      - go.mod
+      - go.sum
+      - main.go
+      - Makefile
+docker_manifests:
+  # https://goreleaser.com/customization/docker_manifest/
+  - name_template: falcosecurity/event-generator:{{ .Version }}
+    image_templates:
+      - falcosecurity/event-generator:{{ .Version }}-amd64
+      - falcosecurity/event-generator:{{ .Version }}-arm64v8
+  - name_template: falcosecurity/event-generator:latest
+      - falcosecurity/event-generator:latest-amd64
+      - falcosecurity/event-generator:latest-arm64v8
 
 release:
   github:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,15 @@
-FROM golang:1.16.5-alpine3.14 as builder
+FROM alpine:latest as builder
 
 LABEL maintainer="cncf-falco-dev@lists.cncf.io"
 
-RUN apk add --no-cache make bash git build-base
+RUN apk add --no-cache make bash git build-base go
 
 WORKDIR /event-generator
 COPY . .
 
 RUN make
 
-FROM alpine:3.14
+FROM alpine:latest
 
 COPY --from=builder /event-generator/event-generator /bin/event-generator
 


### PR DESCRIPTION
Resolves #57.

The following file has been modified :
Modify Dockerfile,.goreleaser and .circleci/config files to build and push the image for both amd64 and arm64 platforms.

Signed-off-by: odidev odidev@puresoftware.com