### PR TITLE
fix(build): force-set the `pie` build mode to allow arm64 images built on alpine to work

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,6 +11,8 @@ builds:
     - 386
     - arm64
     main: .
+    flags:
+      - -buildmode=pie
     env:
       - CGO_ENABLED=0
     binary: event-generator

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ prepare: clean events/k8saudit/yaml/bundle.go
 
 .PHONY: ${output}
 ${output}:
-	$(GO) build -o $@ ${main}
+	$(GO) build -buildmode=pie -o $@ ${main}
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/master/CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note: it's really useful for the changelog!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind documentation

> /kind tests

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area commands

> /area pkg

> /area events

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Basically, on arm64 the docker image is segfaulting as soon as event-generator starts, at the link phase:
```
Program received signal SIGSEGV, Segmentation fault.
0x0000000000000000 in ?? ()
(gdb) bt
#0  0x0000000000000000 in ?? ()
#1  0x0000000000c131a8 in frame_dummy ()
#2  0x0000ffff8b6ee780 in ?? () from /lib/ld-musl-aarch64.so.1
#3  0x0000fffff8c3b328 in ?? ()
Backtrace stopped: previous frame inner to this frame (corrupt stack?)
```
This is due to https://github.com/docker-library/golang/issues/402 (https://gitlab.alpinelinux.org/alpine/aports/-/issues/13308).

Forcing the `pie` build option fixes the issue.

Note: i tested that a local build on arm64 worked fine; i then tested that switching the docker image from alpine to eg: ubuntu, worked too.
Using ubuntu would increase image size though.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

