### PR TITLE
cleanup(OWNERS): remove inactive approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,12 +1,6 @@
 approvers:
   - leogr
   - fededp
-reviewers:
-  - leodido
-  - fntlnz
-  - kris-nova
-  - leogr
-  - fededp
 emeritus_approvers:
   - leodido
   - fntlnz


### PR DESCRIPTION
What type of PR is this?

/kind cleanup

/kind documentation

Any specific area of the project related to this PR?

/area pkg

What this PR does / why we need it:

For https://github.com/falcosecurity/evolution/issues/157, this PR moves inactive approvers (who had very little or zero contributions over the past 6 months) from approvers to emeritus_approvers in OWNERS.

Which issue(s) this PR fixes:

Special notes for your reviewer: