### PR TITLE
adding an event on reading environment variable from /proc files

### DIFF
--- a/events/syscall/read_environment_variable_fromm_proc.go
+++ b/events/syscall/read_environment_variable_fromm_proc.go
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+/*
+Copyright (C) 2024 The Falco Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package syscall
+
+import (
+	"os/exec"
+
+	"github.com/falcosecurity/event-generator/events"
+)
+
+var _ = events.Register(
+	ReadEnvironmentVariableFromProcFiles,
+	events.WithDisabled(), // this rule is not included in falco_rules.yaml (stable rules), so disable the action
+)
+
+func ReadEnvironmentVariableFromProcFiles(h events.Helper) error {
+	if h.InContainer() {
+		cmd := exec.Command("cat", "/proc/self/environ")
+		err := cmd.Run()
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note: it's really useful for the changelog!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind documentation

> /kind tests

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area commands

> /area pkg

/area events

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:
this event trigger rule `read environment variable from /proc file`
**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #111 

**Special notes for your reviewer**:

