### PR TITLE
Fix: In ExecutionFromDevShm we should use os.Mkdir("/dev") instead if os.Mkdir("/dev/shm")

### DIFF
--- a/events/syscall/execution_from_dev_shm.go
+++ b/events/syscall/execution_from_dev_shm.go
@@ -29,7 +29,7 @@ func ExecutionFromDevShm(h events.Helper) error {
 
 	// Check if /dev exists
 	if _, err := os.Stat("/dev"); os.IsNotExist(err) {
-		if err := os.Mkdir("/dev/shm", 0755); err != nil {
+		if err := os.Mkdir("/dev", 0755); err != nil {
 			return err
 		}
 		defer os.RemoveAll("/dev") // Remove dev directory


### PR DESCRIPTION
@FedeDP @leogr As os.Mkdir("/dev/shm") returns error as /dev not exists so instead we should use os.Mkdir("/dev") which just create /dev. 
And  /dev/shm created in the next lines of code


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note: it's really useful for the changelog!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind documentation

> /kind tests

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area commands

> /area pkg

/area events

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

