### PR TITLE
Feature: Added declarative subcommand for test command

### DIFF
--- a/cmd/declarativetest.go
+++ b/cmd/declarativetest.go
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: Apache-2.0
+/*
+Copyright (C) 2024 The Falco Authors.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/falcosecurity/event-generator/pkg/tester"
+	logger "github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+// NewDeclarative instantiates the declarative subcommand for test command.
+func NewDeclarativeTest() *cobra.Command {
+	c := &cobra.Command{
+		Use:   "declarative [yaml-file-path]",
+		Short: "Execute and test Falco rules using a declarative approach",
+		Long: `This command takes the path to a YAML file as an argument. 
+		The YAML file defines tests that are parsed and executed, 
+		and checks if specific Falco rules are triggered.`,
+		Args:              cobra.MaximumNArgs(1),
+		DisableAutoGenTag: true,
+	}
+
+	var testTimeout time.Duration
+	flags := c.Flags()
+	flags.DurationVar(&testTimeout, "test-timeout", tester.DefaultTestTimeout, "Test duration timeout")
+
+	grpcCfg := grpcFlags(flags)
+
+	c.RunE = func(c *cobra.Command, args []string) error {
+		t, err := tester.New(grpcCfg, tester.WithTestTimeout(testTimeout))
+		if err != nil {
+			return err
+		}
+
+		tests, err := parseYamlFile(args[0])
+		if err != nil {
+			return err
+		}
+
+		var failedTests []error // stores the errors of failed tests
+
+		// Execute each test in the YAML file
+		for _, eachTest := range tests.Tests {
+			// Execute the test steps
+			err := runTestSteps(eachTest)
+			if err != nil {
+				failedTests = append(failedTests, fmt.Errorf("test %v failed with err: %v", eachTest.Rule, err))
+				continue
+			}
+
+			// Prepare the logger
+			log := logger.WithField("test", eachTest.Rule)
+
+			// Test if the Falco rule is triggered
+			err = t.PostRun(context.Background(), log, "declarative."+eachTest.Rule, nil, nil)
+			if err != nil {
+				failedTests = append(failedTests, fmt.Errorf("falco rule %v did not trigger as expected: %v", eachTest.Rule, err))
+			}
+		}
+
+		// Print all errors
+		if len(failedTests) > 0 {
+			for _, ft := range failedTests {
+				fmt.Println(ft)
+			}
+			return fmt.Errorf("some tests failed, see previous logs")
+		}
+
+		return nil
+	}
+
+	return c
+}

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -54,5 +54,7 @@ Without arguments it tests all actions, otherwise only those actions matching th
 		return runEWithOpts(c, args, runner.WithPlugin(t))
 	}
 
+	c.AddCommand(NewDeclarativeTest())
+
 	return c
 }

--- a/events/exampleyamlfile.yml
+++ b/events/exampleyamlfile.yml
@@ -21,17 +21,6 @@ tests:
           mode: 0644
     after: ""
 
-  - rule: ReadSensitiveFileTrustedAfterStartup
-    runner: HostRunner
-    before: ""
-    steps:
-      - syscall: "open"
-        args:
-          filepath: "/etc/shadow"
-          flag: 0
-          mode: 0644
-    after: ""
-  
   - rule: ClearLogActivities
     runner: HostRunner
     before: "mkdir /tmp/created-by-event-generator && touch /tmp/created-by-event-generator/syslog"
@@ -63,8 +52,10 @@ tests:
           newpath: "/created-by-event-generator/newpath"
     after: "rm /created-by-event-generator/newpath && rmdir /created-by-event-generator"
 
-  - rule: LaunchIngressRemoteFileCopyToolsInsideContainer
-    runner: ContainerRunner
-    before: "wget example.com"
-    steps: 
-    after: ""
+
+  # not a stable rule 
+  # - rule: LaunchIngressRemoteFileCopyToolsInsideContainer
+  #   runner: ContainerRunner
+  #   before: "wget example.com"
+  #   steps: 
+  #   after: ""


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note: it's really useful for the changelog!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind documentation

> /kind tests

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area commands

> /area pkg

> /area events

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:
It adds a declarative sub-command for the test command. Which takes yaml file path and parses it and runs the tests similar to the run declarative functionality which we added earlier and it also tests whether a falco rule is triggered or not by connecting to the running falco instance through grpc api.
 
**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
@alacuku @jasondellaluce 

