### PR TITLE
increase timeout for syscall.DisallowedSSHConnectionNonStandardPort

### DIFF
--- a/events/syscall/disallowed_ssh_connection_non_standard_port.go
+++ b/events/syscall/disallowed_ssh_connection_non_standard_port.go
@@ -34,7 +34,8 @@ func DisallowedSSHConnectionNonStandardPort(h events.Helper) error {
 	}
 
 	// note: executing the following command might fail, but enough to trigger the rule, so we ignore any error
-	if err := runCmd(context.Background(), 1*time.Second, ssh, "user@example.com", "-p", "443"); err != nil {
+	// in some cases it takes more than one second to establish the connection
+	if err := runCmd(context.Background(), 5*time.Second, ssh, "user@example.com", "-p", "443"); err != nil {
 		h.Log().WithError(err).Debug("failed to run ssh command (this is expected)")
 	}
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**Any specific area of the project related to this PR?**

/area events

**What this PR does / why we need it**:

on some systems, the syscall.DisallowedSSHConnectionNonStandardPort event does not trigger due to too short timeout of 1s, so we're increasing it to 5s

**Which issue(s) this PR fixes**:

Fixes #221 

**Special notes for your reviewer**:

//cc: @leogr i was able to reproduce the issue on lima and arm64 mac, but have not seen it on minikube or "vanilla" ubuntu kvm vm on linux x86/amd64 before: `signal: killed` comes from the context timeout that was apparently too short in this case
```
$ falco --version
Fri Sep 20 19:09:58 2024: Falco version: 0.38.2 (aarch64)
Fri Sep 20 19:09:58 2024: Falco initialized with configuration files:
Fri Sep 20 19:09:58 2024:    /etc/falco/falco.yaml
Fri Sep 20 19:09:58 2024: System info: Linux version 6.8.0-41-generic (buildd@bos03-arm64-063) (aarch64-linux-gnu-gcc-13 (Ubuntu 13.2.0-23ubuntu4) 13.2.0, GNU ld (GNU Binutils for Ubuntu) 2.42) #41-Ubuntu SMP PREEMPT_DYNAMIC Fri Aug  2 23:26:06 UTC 2024
Falco version: 0.38.2
Libs version:  0.17.3
Plugin API:    3.6.0
Engine:        0.40.0
Driver:
  API version:    8.0.0
  Schema version: 2.0.0
  Default driver: 7.2.1+driver
```
```
$ sudo ./event-generator -l debug test syscall.DisallowedSSH
DEBU running with args: ./event-generator -l debug test syscall.DisallowedSSH
DEBU running without a configuration file
DEBU running with options                          loglevel=debug
INFO sleep for 100ms                               action=syscall.DisallowedSSHConnectionNonStandardPort
DEBU failed to run ssh command (this is expected)  action=syscall.DisallowedSSHConnectionNonStandardPort error="exit status 255"
INFO test passed                                   action=syscall.DisallowedSSHConnectionNonStandardPort rule="Disallowed SSH Connection Non Standard Port" source=syscall
```