### PR TITLE
build: fix cross-compilation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ test: events/k8saudit/yaml/bundle.go
 	$(GO) test ${TEST_FLAGS} ./...
 
 events/k8saudit/yaml/bundle.go: events/k8saudit/yaml events/k8saudit/yaml/*.yaml
-	$(GO) run ./tools/file-bundler/ $<
+	GOOS= GOARCH= $(GO) run ./tools/file-bundler/ $<
 
 .PHONY: ${docgen}
 ${docgen}: ${PWD}/tools/docgen/docgen.go


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note: it's really useful for the changelog!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind documentation

> /kind tests

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area commands

> /area pkg

> /area events

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

On a Mac M1, trying to cross-compile for linux/amd64 fails when trying to run the `file-bundler` tool with the wrong arch:

```
$ GOOS=linux GOARCH=amd64 make
rm -f -R event-generator
rm -f events/k8saudit/yaml/bundle.go
rm -f -R event-generator evtgen-docgen
go run ./tools/file-bundler/ events/k8saudit/yaml
fork/exec /var/folders/t_/1ckd5szj47g4pcb36j5zgmnr0000gp/T/go-build630400765/b001/exe/file-bundler: exec format error
make: *** [events/k8saudit/yaml/bundle.go] Error 1
```

After this fix unsetting the values for those vars to use the system default it works:

```
$ GOOS=linux GOARCH=amd64 make
rm -f -R event-generator
rm -f events/k8saudit/yaml/bundle.go
rm -f -R event-generator evtgen-docgen
GOOS= GOARCH= go run ./tools/file-bundler/ events/k8saudit/yaml
CGO_ENABLED=0 go build -buildmode=pie -buildvcs=false -ldflags "-X k8s.io/client-go/pkg/version.gitCommit=v0.31.1 -X k8s.io/client-go/pkg/version.gitVersion=v0.12.0-3-g120ae6f" -o event-generator .
```

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

