### PR TITLE
feat(decl/resources): adds fd test resource and test resource builder

### DIFF
--- a/pkg/test/loader/loader.go
+++ b/pkg/test/loader/loader.go
@@ -175,7 +175,7 @@ type ProcessContext struct {
 type TestResource struct {
 	Type TestResourceType `yaml:"type" validate:"-"`
 	Name string           `yaml:"name" validate:"required"`
-	Spec any              `yaml:"-" validate:"-"`
+	Spec any              `yaml:"-"`
 }
 
 // UnmarshalYAML populates the TestResource instance by unmarshalling the content of the provided YAML node.
@@ -287,7 +287,7 @@ func (t *TestResourceClientServerL4Proto) UnmarshalYAML(node *yaml.Node) error {
 type TestStep struct {
 	Type          TestStepType            `yaml:"type" validate:"-"`
 	Name          string                  `yaml:"name" validate:"required"`
-	Spec          any                     `yaml:"-" validate:"-"`
+	Spec          any                     `yaml:"-"`
 	FieldBindings []*TestStepFieldBinding `yaml:"-" validate:"-"`
 }
 

--- a/pkg/test/loader/loader.go
+++ b/pkg/test/loader/loader.go
@@ -192,14 +192,13 @@ func (r *TestResource) UnmarshalYAML(node *yaml.Node) error {
 	var spec any
 	switch decodedType {
 	case TestResourceTypeClientServer:
-		var clientServerSpec TestResourceClientServerSpec
-		if err := node.Decode(&clientServerSpec); err != nil {
-			return fmt.Errorf("error decoding clientServer test resource spec: %w", err)
-		}
-
-		spec = &clientServerSpec
+		spec = &TestResourceClientServerSpec{}
 	default:
 		panic(fmt.Sprintf("unknown test resource type %q", decodedType))
+	}
+
+	if err := node.Decode(spec); err != nil {
+		return fmt.Errorf("error decoding clientServer test resource spec: %w", err)
 	}
 
 	r.Name = v.Name

--- a/pkg/test/resource/builder/builder.go
+++ b/pkg/test/resource/builder/builder.go
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2024 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package builder
+
+import (
+	"fmt"
+
+	"github.com/go-logr/logr"
+
+	"github.com/falcosecurity/event-generator/pkg/test/loader"
+	"github.com/falcosecurity/event-generator/pkg/test/resource"
+	"github.com/falcosecurity/event-generator/pkg/test/resource/clientserver"
+	"github.com/falcosecurity/event-generator/pkg/test/resource/fd/directory"
+	"github.com/falcosecurity/event-generator/pkg/test/resource/fd/epoll"
+	"github.com/falcosecurity/event-generator/pkg/test/resource/fd/event"
+	"github.com/falcosecurity/event-generator/pkg/test/resource/fd/file"
+	"github.com/falcosecurity/event-generator/pkg/test/resource/fd/inotify"
+	"github.com/falcosecurity/event-generator/pkg/test/resource/fd/mem"
+	"github.com/falcosecurity/event-generator/pkg/test/resource/fd/pipe"
+	"github.com/falcosecurity/event-generator/pkg/test/resource/fd/signal"
+)
+
+// builder is an implementation of resource.Builder.
+type builder struct{}
+
+// Verify that builder implements resource.Builder interface.
+var _ resource.Builder = (*builder)(nil)
+
+// New creates a new builder.
+func New() (resource.Builder, error) {
+	return &builder{}, nil
+}
+
+func (b *builder) Build(logger logr.Logger, testResource *loader.TestResource) (resource.Resource, error) {
+	resourceType := testResource.Type
+	resourceName := testResource.Name
+	logger = logger.WithValues("resourceType", resourceType, "resourceName", resourceName)
+	switch resourceType {
+	case loader.TestResourceTypeClientServer:
+		clientServerSpec, ok := testResource.Spec.(*loader.TestResourceClientServerSpec)
+		if !ok {
+			return nil, fmt.Errorf("cannot parse clientServer spec")
+		}
+
+		// TODO: remove the cast and use a dedicated type for l4Proto
+		res := clientserver.New(logger, resourceName, string(clientServerSpec.L4Proto), clientServerSpec.Address)
+		return res, nil
+	case loader.TestResourceTypeFD:
+		fdSpec, ok := testResource.Spec.(*loader.TestResourceFDSpec)
+		if !ok {
+			return nil, fmt.Errorf("cannot parse fd spec")
+		}
+
+		res, err := b.buildFD(logger, resourceName, fdSpec)
+		if err != nil {
+			return nil, fmt.Errorf("cannot build fd resource: %w", err)
+		}
+
+		return res, nil
+	default:
+		return nil, fmt.Errorf("unknown test resource type %q", resourceType)
+	}
+}
+
+// buildFD builds a fd test resource.
+func (b *builder) buildFD(logger logr.Logger, resourceName string,
+	fdSpec *loader.TestResourceFDSpec) (resource.Resource, error) {
+	subtype := fdSpec.Subtype
+	logger = logger.WithValues("resourceSubtype", subtype)
+	switch subtype {
+	case loader.TestResourceFDSubtypeFile:
+		subSpec, ok := fdSpec.Spec.(*loader.TestResourceFDFileSpec)
+		if !ok {
+			return nil, fmt.Errorf("cannot parse file spec")
+		}
+
+		return file.New(logger, resourceName, subSpec.FilePath), nil
+	case loader.TestResourceFDSubtypeDirectory:
+		subSpec, ok := fdSpec.Spec.(*loader.TestResourceFDDirectorySpec)
+		if !ok {
+			return nil, fmt.Errorf("cannot parse directory spec")
+		}
+
+		return directory.New(logger, resourceName, subSpec.DirPath), nil
+	case loader.TestResourceFDSubtypePipe:
+		if _, ok := fdSpec.Spec.(*loader.TestResourceFDPipeSpec); !ok {
+			return nil, fmt.Errorf("cannot parse pipe spec")
+		}
+
+		return pipe.New(logger, resourceName), nil
+	case loader.TestResourceFDSubtypeEvent:
+		if _, ok := fdSpec.Spec.(*loader.TestResourceFDEventSpec); !ok {
+			return nil, fmt.Errorf("cannot parse event spec")
+		}
+
+		return event.New(logger, resourceName), nil
+	case loader.TestResourceFDSubtypeSignal:
+		if _, ok := fdSpec.Spec.(*loader.TestResourceFDSignalSpec); !ok {
+			return nil, fmt.Errorf("cannot parse signalfd spec")
+		}
+
+		return signal.New(logger, resourceName), nil
+	case loader.TestResourceFDSubtypeEpoll:
+		if _, ok := fdSpec.Spec.(*loader.TestResourceFDEpollSpec); !ok {
+			return nil, fmt.Errorf("cannot parse eventpoll spec")
+		}
+
+		return epoll.New(logger, resourceName), nil
+	case loader.TestResourceFDSubtypeInotify:
+		if _, ok := fdSpec.Spec.(*loader.TestResourceFDInotifySpec); !ok {
+			return nil, fmt.Errorf("cannot parse inotify spec")
+		}
+
+		return inotify.New(logger, resourceName), nil
+	case loader.TestResourceFDSubtypeMem:
+		subSpec, ok := fdSpec.Spec.(*loader.TestResourceFDMemSpec)
+		if !ok {
+			return nil, fmt.Errorf("cannot parse memfd spec")
+		}
+
+		return mem.New(logger, resourceName, subSpec.FileName), nil
+	default:
+		return nil, fmt.Errorf("unknown fd test resource subtype %q", subtype)
+	}
+}

--- a/pkg/test/resource/builder/doc.go
+++ b/pkg/test/resource/builder/doc.go
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2024 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package builder provides an implementation of resource.Builder.
+package builder

--- a/pkg/test/resource/fd/directory/directory.go
+++ b/pkg/test/resource/fd/directory/directory.go
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2024 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package directory
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"reflect"
+
+	"github.com/go-logr/logr"
+	"golang.org/x/sys/unix"
+
+	"github.com/falcosecurity/event-generator/pkg/test/field"
+	"github.com/falcosecurity/event-generator/pkg/test/resource"
+)
+
+// directoryFD implements a directory FD resource.
+type directoryFD struct {
+	logger logr.Logger
+	// resourceName is the fd resource name.
+	resourceName string
+	// filePath is the path of the directory to open/create.
+	dirPath string
+	// created is valid after a successful call to Create and becomes invalid after a call to Destroy. It is true if
+	// Create created a new file, whereas is false if the directory exists and Create simply opened it.
+	created bool
+	// fields defines the information exposed by directoryFD for binding.
+	fields struct {
+		// FD is the directory file descriptor. If the resource has not been Create'd yet, or it has been Destroy'ed, FD
+		// is set to -1.
+		FD int `field_type:"fd"`
+	}
+}
+
+// Verify that directoryFD implements resource.Resource interface.
+var _ resource.Resource = (*directoryFD)(nil)
+
+// New creates a new directory FD resource.
+func New(logger logr.Logger, resourceName, dirPath string) resource.Resource {
+	d := &directoryFD{
+		logger:       logger,
+		resourceName: resourceName,
+		dirPath:      dirPath,
+	}
+	d.fields.FD = -1
+	return d
+}
+
+func (d *directoryFD) Name() string {
+	return d.resourceName
+}
+
+// Create opens or creates a directory and exposes its file descriptor.
+func (d *directoryFD) Create(_ context.Context) error {
+	if d.fields.FD != -1 {
+		return fmt.Errorf("directory %q is already open", d.dirPath)
+	}
+
+	created, fd, err := d.openOrCreateDir(d.dirPath)
+	if err != nil {
+		return fmt.Errorf("error opening/creating directory %q: %w", d.dirPath, err)
+	}
+
+	d.created = created
+	d.fields.FD = fd
+	return nil
+}
+
+// openOrCreateFile opens or creates a directory at the provided path. It returns a boolean value indicating if the
+// directory has been created and the file descriptor of the opened directory.
+func (d *directoryFD) openOrCreateDir(dirPath string) (created bool, dirFD int, err error) {
+	// Check for path existence. If it doesn't exist, creates the directory. If it exists, verify it is a directory.
+	stat, err := os.Stat(dirPath)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return false, 0, fmt.Errorf("error verifying path existence: %w", err)
+		}
+
+		if err := unix.Mkdir(dirPath, unix.S_IRUSR|unix.S_IWUSR); err != nil {
+			return false, 0, fmt.Errorf("error creating directory: %w", err)
+		}
+
+		created = true
+	} else if !stat.IsDir() {
+		return false, 0, fmt.Errorf("path exists and is not a directory")
+	}
+
+	// Open the directory
+	fd, err := unix.Open(dirPath, unix.O_RDONLY|unix.O_DIRECTORY, 0)
+	if err != nil {
+		if created {
+			if err := unix.Rmdir(dirPath); err != nil {
+				d.logger.Error(err, "error deleting directory", "path", dirPath)
+			}
+		}
+		return false, 0, fmt.Errorf("error opening directory: %w", err)
+	}
+
+	return created, fd, nil
+}
+
+// Destroy closes the exposed file descriptor and deletes the underlying directory (if it was created by Create).
+func (d *directoryFD) Destroy(_ context.Context) error {
+	dirPath := d.dirPath
+
+	if d.fields.FD == -1 {
+		return fmt.Errorf("directory %q is not open", dirPath)
+	}
+
+	defer func() {
+		d.created = false
+		d.fields.FD = -1
+	}()
+
+	logger := d.logger.WithValues("dirPath", d.dirPath)
+
+	// Close the file descriptor.
+	if err := unix.Close(d.fields.FD); err != nil {
+		logger.Error(err, "Error closing directory")
+	}
+
+	if !d.created {
+		return nil
+	}
+
+	// Delete the directory.
+	if err := unix.Rmdir(dirPath); err != nil {
+		logger.Error(err, "Error removing created directory")
+	}
+
+	return nil
+}
+
+func (d *directoryFD) Field(name string) (*field.Field, error) {
+	fieldContainer := reflect.ValueOf(d.fields)
+	return field.ByName(name, fieldContainer)
+}

--- a/pkg/test/resource/fd/directory/doc.go
+++ b/pkg/test/resource/fd/directory/doc.go
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2024 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package directory provides the implementation of a directory fd test resource. The resource exposes a 'fd' field,
+// referring to a directory, that can be used in field binding.
+package directory

--- a/pkg/test/resource/fd/epoll/doc.go
+++ b/pkg/test/resource/fd/epoll/doc.go
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2024 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package epoll provides the implementation of an eventpoll fd test resource. The resource exposes the epoll fd (that
+// can be used for binding) in the 'fd' field.
+package epoll

--- a/pkg/test/resource/fd/epoll/epoll.go
+++ b/pkg/test/resource/fd/epoll/epoll.go
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2024 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package epoll
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	"github.com/go-logr/logr"
+	"golang.org/x/sys/unix"
+
+	"github.com/falcosecurity/event-generator/pkg/test/field"
+	"github.com/falcosecurity/event-generator/pkg/test/resource"
+)
+
+// epollFD implements an epoll FD resource.
+type epollFD struct {
+	logger logr.Logger
+	// resourceName is the fd resource name.
+	resourceName string
+	// fields defines the information exposed by epollFD for binding.
+	fields struct {
+		// FD is the epoll file descriptor. If the resource has not been Create'd yet, or it has been Destroy'ed, FD is
+		// set to -1.
+		FD int `field_type:"fd"`
+	}
+}
+
+// Verify that epollFD implements resource.Resource interface.
+var _ resource.Resource = (*epollFD)(nil)
+
+// New creates a new epoll FD resource.
+func New(logger logr.Logger, resourceName string) resource.Resource {
+	e := &epollFD{
+		logger:       logger,
+		resourceName: resourceName,
+	}
+	e.fields.FD = -1
+	return e
+}
+
+func (e *epollFD) Name() string {
+	return e.resourceName
+}
+
+// Create creates an epoll file descriptor and exposes it.
+func (e *epollFD) Create(_ context.Context) error {
+	if e.fields.FD != -1 {
+		return fmt.Errorf("epoll FD is already open")
+	}
+
+	fd, err := createEpollFD()
+	if err != nil {
+		return fmt.Errorf("error creating epoll FD: %w", err)
+	}
+
+	e.fields.FD = fd
+	return nil
+}
+
+// createEpollFD creates a new epoll file descriptor and returns it.
+func createEpollFD() (int, error) {
+	fd, err := unix.EpollCreate1(0)
+	if err != nil {
+		return 0, err
+	}
+
+	return fd, nil
+}
+
+// Destroy closes the exposed file descriptor.
+func (e *epollFD) Destroy(_ context.Context) error {
+	if e.fields.FD == -1 {
+		return fmt.Errorf("epoll FD is not open")
+	}
+
+	defer func() {
+		e.fields.FD = -1
+	}()
+
+	if err := unix.Close(e.fields.FD); err != nil {
+		e.logger.Error(err, "Error closing epoll FD")
+	}
+
+	return nil
+}
+
+func (e *epollFD) Field(name string) (*field.Field, error) {
+	fieldContainer := reflect.ValueOf(e.fields)
+	return field.ByName(name, fieldContainer)
+}

--- a/pkg/test/resource/fd/event/doc.go
+++ b/pkg/test/resource/fd/event/doc.go
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2024 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package event provides the implementation of an event fd test resource. The resource exposes the event fd (that can
+// be used for binding) in the 'fd' field.
+package event

--- a/pkg/test/resource/fd/event/event.go
+++ b/pkg/test/resource/fd/event/event.go
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2024 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package event
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	"github.com/go-logr/logr"
+	"golang.org/x/sys/unix"
+
+	"github.com/falcosecurity/event-generator/pkg/test/field"
+	"github.com/falcosecurity/event-generator/pkg/test/resource"
+)
+
+// eventFD implements an event FD resource.
+type eventFD struct {
+	logger logr.Logger
+	// resourceName is the fd resource name.
+	resourceName string
+	// fields defines the information exposed by eventFD for binding.
+	fields struct {
+		// FD is the event file descriptor. If the resource has not been Create'd yet, or it has been Destroy'ed, FD is
+		// set to -1.
+		FD int `field_type:"fd"`
+	}
+}
+
+// Verify that eventFD implements resource.Resource interface.
+var _ resource.Resource = (*eventFD)(nil)
+
+// New creates a new event FD resource.
+func New(logger logr.Logger, resourceName string) resource.Resource {
+	e := &eventFD{
+		logger:       logger,
+		resourceName: resourceName,
+	}
+	e.fields.FD = -1
+	return e
+}
+
+func (e *eventFD) Name() string {
+	return e.resourceName
+}
+
+// Create creates an event file descriptor and exposes it.
+func (e *eventFD) Create(_ context.Context) error {
+	if e.fields.FD != -1 {
+		return fmt.Errorf("event FD is already open")
+	}
+
+	fd, err := createEventFD()
+	if err != nil {
+		return fmt.Errorf("error creating event FD: %w", err)
+	}
+
+	e.fields.FD = fd
+	return nil
+}
+
+// createEventFD creates a new event file descriptor and returns it.
+func createEventFD() (int, error) {
+	fd, err := unix.Eventfd(0, 0)
+	if err != nil {
+		return 0, err
+	}
+
+	return fd, nil
+}
+
+// Destroy closes the exposed file descriptor.
+func (e *eventFD) Destroy(_ context.Context) error {
+	if e.fields.FD == -1 {
+		return fmt.Errorf("event FD is not open")
+	}
+
+	defer func() {
+		e.fields.FD = -1
+	}()
+
+	if err := unix.Close(e.fields.FD); err != nil {
+		e.logger.Error(err, "Error closing event FD")
+	}
+
+	return nil
+}
+
+func (e *eventFD) Field(name string) (*field.Field, error) {
+	fieldContainer := reflect.ValueOf(e.fields)
+	return field.ByName(name, fieldContainer)
+}

--- a/pkg/test/resource/fd/file/doc.go
+++ b/pkg/test/resource/fd/file/doc.go
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2024 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package file provides the implementation of a regular file fd test resource. The resource exposes a 'fd' field,
+// referring to a regular file, that can be used in field binding.
+package file

--- a/pkg/test/resource/fd/file/file.go
+++ b/pkg/test/resource/fd/file/file.go
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2024 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package file
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"reflect"
+
+	"github.com/go-logr/logr"
+	"golang.org/x/sys/unix"
+
+	"github.com/falcosecurity/event-generator/pkg/test/field"
+	"github.com/falcosecurity/event-generator/pkg/test/resource"
+)
+
+// regularFD implements a regular file FD resource.
+type regularFD struct {
+	logger logr.Logger
+	// resourceName is the fd resource name.
+	resourceName string
+	// filePath is the path of the file to open/create.
+	filePath string
+	// created is valid after a successful call to Create and becomes invalid after a call to Destroy. It is true if
+	// Create created a new file, whereas is false if the file exists and Create simply opened it.
+	created bool
+	// fields defines the information exposed by regularFD for binding.
+	fields struct {
+		// FD is the regular file descriptor. If the resource has not been Create'd yet, or it has been Destroy'ed, FD
+		// is set to -1.
+		FD int `field_type:"fd"`
+	}
+}
+
+// Verify that regularFD implements resource.Resource interface.
+var _ resource.Resource = (*regularFD)(nil)
+
+// New creates a new regular file FD resource.
+func New(logger logr.Logger, resourceName, filePath string) resource.Resource {
+	cs := &regularFD{
+		logger:       logger,
+		resourceName: resourceName,
+		filePath:     filePath,
+	}
+	cs.fields.FD = -1
+	return cs
+}
+
+func (r *regularFD) Name() string {
+	return r.resourceName
+}
+
+// Create opens or creates a regular file and exposes its file descriptor.
+func (r *regularFD) Create(_ context.Context) error {
+	if r.fields.FD != -1 {
+		return fmt.Errorf("file %q is already open", r.filePath)
+	}
+
+	created, fd, err := openOrCreateFile(r.filePath)
+	if err != nil {
+		return fmt.Errorf("error opening/creating file %q: %w", r.filePath, err)
+	}
+
+	r.created = created
+	r.fields.FD = fd
+	return nil
+}
+
+// openOrCreateFile opens or creates a regular file at the provided path.
+func openOrCreateFile(path string) (created bool, fileFD int, err error) {
+	mustCreate := false
+
+	// Check for file existence.
+	if _, err := os.Stat(path); err != nil {
+		if !os.IsNotExist(err) {
+			return false, 0, fmt.Errorf("error verifying file existence: %w", err)
+		}
+
+		mustCreate = true
+	}
+
+	// Open/Create the file.
+	flags := unix.O_RDWR
+	if mustCreate {
+		flags |= unix.O_CREAT
+	}
+	fd, err := unix.Open(path, flags, 0)
+	if err != nil {
+		return false, 0, fmt.Errorf("error opening the file: %w", err)
+	}
+
+	return mustCreate, fd, nil
+}
+
+// Destroy closes the exposed file descriptor and deletes the underlying file (if it was created by Create).
+func (r *regularFD) Destroy(_ context.Context) error {
+	filePath := r.filePath
+
+	if r.fields.FD == -1 {
+		return fmt.Errorf("file %q is not open", filePath)
+	}
+
+	defer func() {
+		r.fields.FD = -1
+		r.created = false
+	}()
+
+	logger := r.logger.WithValues("filePath", filePath)
+
+	// Close the file descriptor.
+	if err := unix.Close(r.fields.FD); err != nil {
+		logger.Error(err, "Error closing file")
+	}
+
+	if !r.created {
+		return nil
+	}
+
+	// Delete the file.
+	if err := unix.Unlink(filePath); err != nil {
+		logger.Error(err, "Error removing created file")
+	}
+
+	return nil
+}
+
+func (r *regularFD) Field(name string) (*field.Field, error) {
+	fieldContainer := reflect.ValueOf(r.fields)
+	return field.ByName(name, fieldContainer)
+}

--- a/pkg/test/resource/fd/inotify/doc.go
+++ b/pkg/test/resource/fd/inotify/doc.go
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2024 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package inotify provides the implementation of an inotify fd test resource. The resource exposes the inotify fd (that
+// can be used for binding) in the 'fd' field.
+package inotify

--- a/pkg/test/resource/fd/inotify/inotify.go
+++ b/pkg/test/resource/fd/inotify/inotify.go
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2024 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package inotify
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	"github.com/go-logr/logr"
+	"golang.org/x/sys/unix"
+
+	"github.com/falcosecurity/event-generator/pkg/test/field"
+	"github.com/falcosecurity/event-generator/pkg/test/resource"
+)
+
+// inotifyFD implements an inotify FD resource.
+type inotifyFD struct {
+	logger logr.Logger
+	// resourceName is the fd resource name.
+	resourceName string
+	// fields defines the information exposed by inotifyFD for binding.
+	fields struct {
+		// FD is the inotify file descriptor. If the resource has not been Create'd yet, or it has been Destroy'ed, FD
+		// is set to -1.
+		FD int `field_type:"fd"`
+	}
+}
+
+// Verify that inotifyFD implements resource.Resource interface.
+var _ resource.Resource = (*inotifyFD)(nil)
+
+// New creates a new inotify FD resource.
+func New(logger logr.Logger, resourceName string) resource.Resource {
+	i := &inotifyFD{
+		logger:       logger,
+		resourceName: resourceName,
+	}
+	i.fields.FD = -1
+	return i
+}
+
+func (i *inotifyFD) Name() string {
+	return i.resourceName
+}
+
+// Create creates an inotify file descriptor and exposes it.
+func (i *inotifyFD) Create(_ context.Context) error {
+	if i.fields.FD != -1 {
+		return fmt.Errorf("inotify FD is already open")
+	}
+
+	fd, err := createInotifyFD()
+	if err != nil {
+		return fmt.Errorf("error creating inotify FD: %w", err)
+	}
+
+	i.fields.FD = fd
+	return nil
+}
+
+// createInotifyFD creates a new inotify file descriptor and returns it.
+func createInotifyFD() (int, error) {
+	fd, err := unix.InotifyInit()
+	if err != nil {
+		return 0, err
+	}
+
+	return fd, nil
+}
+
+// Destroy closes the exposed file descriptor.
+func (i *inotifyFD) Destroy(_ context.Context) error {
+	if i.fields.FD == -1 {
+		return fmt.Errorf("inotify FD is not open")
+	}
+
+	defer func() {
+		i.fields.FD = -1
+	}()
+
+	if err := unix.Close(i.fields.FD); err != nil {
+		i.logger.Error(err, "Error closing inotify FD")
+	}
+
+	return nil
+}
+
+func (i *inotifyFD) Field(name string) (*field.Field, error) {
+	fieldContainer := reflect.ValueOf(i.fields)
+	return field.ByName(name, fieldContainer)
+}

--- a/pkg/test/resource/fd/mem/doc.go
+++ b/pkg/test/resource/fd/mem/doc.go
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2024 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package mem provides the implementation of a memfd fd test resource. The resource exposes the mem fd (that can
+// be used for binding) in the 'fd' field.
+package mem

--- a/pkg/test/resource/fd/mem/mem.go
+++ b/pkg/test/resource/fd/mem/mem.go
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2024 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mem
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	"github.com/go-logr/logr"
+	"golang.org/x/sys/unix"
+
+	"github.com/falcosecurity/event-generator/pkg/test/field"
+	"github.com/falcosecurity/event-generator/pkg/test/resource"
+)
+
+// memFD implements a mem FD resource.
+type memFD struct {
+	logger logr.Logger
+	// resourceName is the fd resource name.
+	resourceName string
+	// fileName is the file name associated with the mem FD.
+	fileName string
+	// fields defines the information exposed by memFD for binding.
+	fields struct {
+		FD int `field_type:"fd"`
+	}
+}
+
+// Verify that memFD implements resource.Resource interface.
+var _ resource.Resource = (*memFD)(nil)
+
+// New creates a new mem FD resource.
+func New(logger logr.Logger, resourceName, fileName string) resource.Resource {
+	m := &memFD{
+		logger:       logger,
+		resourceName: resourceName,
+		fileName:     fileName,
+	}
+	m.fields.FD = -1
+	return m
+}
+
+func (m *memFD) Name() string {
+	return m.resourceName
+}
+
+// Create creates a mem file descriptor and exposes it.
+func (m *memFD) Create(_ context.Context) error {
+	if m.fields.FD != -1 {
+		return fmt.Errorf("mem FD %q is already open", m.fileName)
+	}
+
+	fd, err := createMemFD(m.fileName)
+	if err != nil {
+		return fmt.Errorf("error creating mem FD %q: %w", m.fileName, err)
+	}
+
+	m.fields.FD = fd
+	return nil
+}
+
+// createMemFD creates a new mem file descriptor with the provided name and returns it.
+func createMemFD(name string) (int, error) {
+	fd, err := unix.MemfdCreate(name, 0)
+	if err != nil {
+		return 0, err
+	}
+
+	return fd, nil
+}
+
+// Destroy closes the exposed file descriptor.
+func (m *memFD) Destroy(_ context.Context) error {
+	if m.fields.FD == -1 {
+		return fmt.Errorf("mem FD %q is not open", m.fileName)
+	}
+
+	defer func() {
+		m.fields.FD = -1
+	}()
+
+	if err := unix.Close(m.fields.FD); err != nil {
+		m.logger.Error(err, "Error closing mem FD", "fileName", m.fileName)
+	}
+
+	return nil
+}
+
+func (m *memFD) Field(name string) (*field.Field, error) {
+	fieldContainer := reflect.ValueOf(m.fields)
+	return field.ByName(name, fieldContainer)
+}

--- a/pkg/test/resource/fd/pipe/doc.go
+++ b/pkg/test/resource/fd/pipe/doc.go
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2024 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package pipe provides the implementation of a pipe fd test resource. The resource exposes the 'readFd' and 'writeFd'
+// fields, referring to two pipe ends, that can be used in field binding.
+package pipe

--- a/pkg/test/resource/fd/pipe/pipe.go
+++ b/pkg/test/resource/fd/pipe/pipe.go
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2024 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pipe
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	"github.com/go-logr/logr"
+	"golang.org/x/sys/unix"
+
+	"github.com/falcosecurity/event-generator/pkg/test/field"
+	"github.com/falcosecurity/event-generator/pkg/test/resource"
+)
+
+// pipe implements a pipe FD resource.
+type pipe struct {
+	logger logr.Logger
+	// resourceName is the fd resource name.
+	resourceName string
+	// fields defines the information exposed by pipe for binding.
+	fields struct {
+		// ReadFD is the file descriptor of the pipe read end. If the resource has not been Create'd yet, or it has been
+		// Destroy'ed, ReadFD is set to -1.
+		ReadFD int `field_type:"fd"`
+		// WriteFD is the file descriptor of the pipe write end. If the resource has not been Create'd yet, or it has
+		// been Destroy'ed, ReadFD is set to -1.
+		WriteFD int `field_type:"fd"`
+	}
+}
+
+// Verify that pipe implements resource.Resource interface.
+var _ resource.Resource = (*pipe)(nil)
+
+// New creates a new pipe FD resource.
+func New(logger logr.Logger, resourceName string) resource.Resource {
+	p := &pipe{
+		logger:       logger,
+		resourceName: resourceName,
+	}
+	p.fields.ReadFD = -1
+	p.fields.WriteFD = -1
+	return p
+}
+
+func (p *pipe) Name() string {
+	return p.resourceName
+}
+
+// Create a new pipe and exposes its file descriptors.
+func (p *pipe) Create(_ context.Context) error {
+	if p.fields.ReadFD != -1 {
+		return fmt.Errorf("pipe is already open")
+	}
+
+	readFD, writeFD, err := createPipe()
+	if err != nil {
+		return fmt.Errorf("error creating pipe: %w", err)
+	}
+
+	p.fields.ReadFD = readFD
+	p.fields.WriteFD = writeFD
+	return nil
+}
+
+// createPipe creates a new pipe and returns its two file descriptors.
+func createPipe() (readFD, writeFD int, err error) {
+	var fds [2]int
+	if err := unix.Pipe(fds[:]); err != nil {
+		return 0, 0, err
+	}
+
+	return fds[0], fds[1], nil
+}
+
+// Destroy closes the exposed pipe file descriptors.
+func (p *pipe) Destroy(_ context.Context) error {
+	if p.fields.ReadFD == -1 {
+		return fmt.Errorf("pipe is not open")
+	}
+
+	defer func() {
+		p.fields.ReadFD = -1
+		p.fields.WriteFD = -1
+	}()
+
+	if err := unix.Close(p.fields.ReadFD); err != nil {
+		p.logger.Error(err, "Error closing pipe read end")
+	}
+
+	if err := unix.Close(p.fields.WriteFD); err != nil {
+		p.logger.Error(err, "Error closing pipe write end")
+	}
+
+	return nil
+}
+
+func (p *pipe) Field(name string) (*field.Field, error) {
+	fieldContainer := reflect.ValueOf(p.fields)
+	return field.ByName(name, fieldContainer)
+}

--- a/pkg/test/resource/fd/signal/doc.go
+++ b/pkg/test/resource/fd/signal/doc.go
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2024 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package signal provides the implementation of a signal fd test resource. The resource exposes the signal fd (that can
+// be used for binding) in the 'fd' field.
+package signal

--- a/pkg/test/resource/fd/signal/signal.go
+++ b/pkg/test/resource/fd/signal/signal.go
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2024 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package signal
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	"github.com/go-logr/logr"
+	"golang.org/x/sys/unix"
+
+	"github.com/falcosecurity/event-generator/pkg/test/field"
+	"github.com/falcosecurity/event-generator/pkg/test/resource"
+)
+
+// signalFD implements a signal FD resource.
+type signalFD struct {
+	logger logr.Logger
+	// resourceName is the fd resource name.
+	resourceName string
+	// fields defines the information exposed by signalFD for binding.
+	fields struct {
+		// FD is the signal file descriptor. If the resource has not been Create'd yet, or it has been Destroy'ed, FD is
+		// set to -1.
+		FD int `field_type:"fd"`
+	}
+}
+
+// Verify that signalFD implements resource.Resource interface.
+var _ resource.Resource = (*signalFD)(nil)
+
+// New creates a new signal FD resource.
+func New(logger logr.Logger, resourceName string) resource.Resource {
+	s := &signalFD{
+		logger:       logger,
+		resourceName: resourceName,
+	}
+	s.fields.FD = -1
+	return s
+}
+
+func (s *signalFD) Name() string {
+	return s.resourceName
+}
+
+// Create creates a signal file descriptor and exposes it.
+func (s *signalFD) Create(_ context.Context) error {
+	if s.fields.FD != -1 {
+		return fmt.Errorf("signal FD is already open")
+	}
+
+	fd, err := createSignalFD()
+	if err != nil {
+		return fmt.Errorf("error creating signal FD: %w", err)
+	}
+
+	s.fields.FD = fd
+	return nil
+}
+
+// createSignalFD creates a new signal file descriptor and returns it.
+func createSignalFD() (int, error) {
+	fd, err := unix.Signalfd(-1, &unix.Sigset_t{}, 0)
+	if err != nil {
+		return 0, err
+	}
+
+	return fd, nil
+}
+
+// Destroy closes the exposed file descriptor.
+func (s *signalFD) Destroy(_ context.Context) error {
+	if s.fields.FD == -1 {
+		return fmt.Errorf("signal FD is not open")
+	}
+
+	defer func() {
+		s.fields.FD = -1
+	}()
+
+	if err := unix.Close(s.fields.FD); err != nil {
+		s.logger.Error(err, "Error closing signal FD")
+	}
+
+	return nil
+}
+
+func (s *signalFD) Field(name string) (*field.Field, error) {
+	fieldContainer := reflect.ValueOf(s.fields)
+	return field.ByName(name, fieldContainer)
+}

--- a/pkg/test/resource/resource.go
+++ b/pkg/test/resource/resource.go
@@ -18,6 +18,8 @@ package resource
 import (
 	"context"
 
+	"github.com/go-logr/logr"
+
 	"github.com/falcosecurity/event-generator/pkg/test/field"
 	"github.com/falcosecurity/event-generator/pkg/test/loader"
 )
@@ -37,5 +39,5 @@ type Resource interface {
 type Builder interface {
 	// Build builds a new test resource.
 	// TODO: replace loader.TestResource with a dedicated type.
-	Build(testResource *loader.TestResource) (Resource, error)
+	Build(logger logr.Logger, testResource *loader.TestResource) (Resource, error)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note: it's really useful for the changelog!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**
> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind documentation

> /kind tests

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area commands

/area pkg

> /area events

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:
This PR adds the `fd` test resource, the test resource builder and fixes some minor issues related to YAML specs validation. The `fd` test resource is a resource that lets the user declaratively create one file descriptor (or more, in case of `pipe`) . The user must specify the fd type using the `subtype` YAML field. The following `subtype`s have been introduced:
- `file`
- `directory`
- `pipe`
- `event`
- `signalfd`
- `eventpoll`
- `inotify`
- `memfd`

Depending on the selected `subtype` more attributes could be required to completely specify the `fd` test resource. For instance, the following is the YAML declaration of a `directory` `fd` test resource:
```
    ...
    resources:
      - type: fd
        name: directory1
        subtype: directory
        dirPath: "/path/to/dir"
    ...
```

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

