### PR TITLE
feat(decl): add CLI support to run declarative tests

### DIFF
--- a/cmd/declarative/declarative.go
+++ b/cmd/declarative/declarative.go
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2024 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package declarative
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/falcosecurity/event-generator/cmd/declarative/run"
+)
+
+// New creates a new declarative command.
+func New(declarativeEnvKey, envKeysPrefix string) *cobra.Command {
+	c := &cobra.Command{
+		Use:               "declarative",
+		Short:             "Run test(s) specified via a YAML description",
+		Long:              "Run test(s) specified via a YAML description",
+		DisableAutoGenTag: true,
+	}
+
+	c.AddCommand(run.New(declarativeEnvKey, envKeysPrefix).Command)
+
+	return c
+}

--- a/cmd/declarative/doc.go
+++ b/cmd/declarative/doc.go
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2024 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package declarative provides the implementation of the "declarative" command.
+package declarative

--- a/cmd/declarative/run/doc.go
+++ b/cmd/declarative/run/doc.go
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2024 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package run provides the implementation of the "run" command. This command lets users run tests by providing a YAML
+// description of them.
+package run

--- a/cmd/declarative/run/run.go
+++ b/cmd/declarative/run/run.go
@@ -1,0 +1,349 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2024 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package run
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/go-logr/logr"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"github.com/falcosecurity/event-generator/pkg/test"
+	testbuilder "github.com/falcosecurity/event-generator/pkg/test/builder"
+	"github.com/falcosecurity/event-generator/pkg/test/loader"
+	resbuilder "github.com/falcosecurity/event-generator/pkg/test/resource/builder"
+	"github.com/falcosecurity/event-generator/pkg/test/runner"
+	runnerbuilder "github.com/falcosecurity/event-generator/pkg/test/runner/builder"
+	stepbuilder "github.com/falcosecurity/event-generator/pkg/test/step/builder"
+	sysbuilder "github.com/falcosecurity/event-generator/pkg/test/step/syscall/builder"
+)
+
+// CommandWrapper is a thin wrapper around the cobra command.
+type CommandWrapper struct {
+	envKeysPrefix     string
+	declarativeEnvKey string
+	// descriptionFileEnvKey is the environment variable key corresponding to testDescriptionFileFlagName.
+	descriptionFileEnvKey string
+	// descriptionEnvKey is the environment variable key corresponding to testDescriptionFlagName.
+	descriptionEnvKey string
+	// procIDEnvKey is the environment variable key corresponding to procIDFlagName.
+	procIDEnvKey string
+	Command      *cobra.Command
+}
+
+const (
+	// descriptionFileFlagName is the name of the flag allowing to specify the path of the file containing the YAML
+	// tests description.
+	descriptionFileFlagName = "description-file"
+	// descriptionFlagName is the name of the flag allowing to specify the YAML tests description.
+	descriptionFlagName = "description"
+	// procIDFlagName is the name of the flag allowing to specify process identifier in the form
+	// test<testIndex>.child<childIndex>.
+	procIDFlagName = "proc-id"
+)
+
+const longDescriptionPrefaceTemplate = `Run tests(s) specified via a YAML description.
+
+It is possible to provide the YAML description in multiple ways. The order of evaluation is the following:
+1) If the --%s=<file_path> flag is provided the description is read from the file at <file_path>
+2) If the --%s=<description> flag is provided, the description is read from the <description> string
+3) Otherwise, it is read from standard input`
+
+var longDescriptionPreface = fmt.Sprintf(longDescriptionPrefaceTemplate, descriptionFileFlagName, descriptionFlagName)
+
+const warningMessage = `Warning:
+  This command might alter your system. For example, some actions modify files and directories below /bin, /etc, /dev,
+  etc... Make sure you fully understand what is the purpose of this tool before running any action.`
+
+var longDescription = fmt.Sprintf("%s\n\n%s", longDescriptionPreface, warningMessage)
+
+// New creates a new run command.
+func New(declarativeEnvKey, envKeysPrefix string) *CommandWrapper {
+	cw := &CommandWrapper{
+		declarativeEnvKey:     declarativeEnvKey,
+		envKeysPrefix:         envKeysPrefix,
+		descriptionFileEnvKey: envKeyFromFlagName(envKeysPrefix, descriptionFileFlagName),
+		descriptionEnvKey:     envKeyFromFlagName(envKeysPrefix, descriptionFlagName),
+		procIDEnvKey:          envKeyFromFlagName(envKeysPrefix, procIDFlagName),
+	}
+
+	c := &cobra.Command{
+		Use:               "run",
+		Short:             "Run test(s) specified via a YAML description",
+		Long:              longDescription,
+		DisableAutoGenTag: true,
+		Run:               cw.run,
+	}
+
+	initFlags(c)
+	cw.Command = c
+	return cw
+}
+
+// envKeyFromFlagName converts the provided flag name into the corresponding environment variable key.
+func envKeyFromFlagName(envKeysPrefix, flagName string) string {
+	s := fmt.Sprintf("%s_%s", envKeysPrefix, strings.ToUpper(flagName))
+	s = strings.ToUpper(s)
+	return strings.ReplaceAll(s, "-", "_")
+}
+
+// initFlags initializes the provided command's flags.
+func initFlags(c *cobra.Command) {
+	flags := c.Flags()
+
+	flags.StringP(descriptionFileFlagName, "f", "",
+		"The tests description YAML file specifying the tests to be run")
+	flags.StringP(descriptionFlagName, "d", "",
+		"The YAML-formatted tests description string specifying the tests to be run")
+	c.MarkFlagsMutuallyExclusive(descriptionFileFlagName, descriptionFlagName)
+
+	flags.StringP(procIDFlagName, "p", "",
+		"The ID uniquely identifying the current process, in the form test<testIndex>.child<childIndex> (used "+
+			"during process chain building)")
+}
+
+// processIDInfo contains information regarding the process ID.
+type processIDInfo struct {
+	testName   string
+	testIndex  int
+	childName  string
+	childIndex int
+}
+
+// run runs the tests from the provided YAML description.
+func (cw *CommandWrapper) run(c *cobra.Command, _ []string) {
+	ctx := c.Context()
+	logger, err := logr.FromContext(ctx)
+	if err != nil {
+		panic(fmt.Sprintf("logger unconfigured: %v", err))
+	}
+
+	flags := c.Flags()
+
+	procIDInfo, err := parseProcID(flags)
+	if err != nil {
+		logger.Error(err, "Error parsing process ID")
+		os.Exit(1)
+	}
+
+	if procIDInfo == nil {
+		logger = logger.WithName("root")
+	} else {
+		logger = logger.WithName(procIDInfo.testName).WithName(procIDInfo.childName)
+	}
+
+	description, err := loadTestsDescription(logger, flags)
+	if err != nil {
+		logger.Error(err, "Error loading tests description")
+		os.Exit(1)
+	}
+
+	resourceBuilder, err := resbuilder.New()
+	if err != nil {
+		logger.Error(err, "Error creating resource builder")
+		os.Exit(1)
+	}
+
+	syscallBuilder := sysbuilder.New()
+	stepBuilder, err := stepbuilder.New(syscallBuilder)
+	if err != nil {
+		logger.Error(err, "Error creating step builder")
+		os.Exit(1)
+	}
+
+	testBuilder, err := testbuilder.New(resourceBuilder, stepBuilder)
+	if err != nil {
+		logger.Error(err, "Error creating test builder")
+		os.Exit(1)
+	}
+
+	runnerBuilder, err := runnerbuilder.New(testBuilder)
+	if err != nil {
+		logger.Error(err, "Error creating runner builder")
+		os.Exit(1)
+	}
+
+	// Prepare parameters shared by runners.
+	runnerLogger := logger.WithName("runner")
+	runnerEnviron := cw.buildRunnerEnviron(c)
+	var runnerProcID string
+	if procIDInfo != nil {
+		runnerProcID = fmt.Sprintf("%s,%s", procIDInfo.testName, procIDInfo.childName)
+	}
+
+	// Build and run the tests.
+	for testIndex := range description.Tests {
+		testDesc := &description.Tests[testIndex]
+
+		runnerDescription := &runner.Description{
+			Logger:                    runnerLogger,
+			Type:                      testDesc.Runner,
+			Environ:                   runnerEnviron,
+			TestDescriptionEnvKey:     cw.descriptionEnvKey,
+			TestDescriptionFileEnvKey: cw.descriptionFileEnvKey,
+			ProcIDEnvKey:              cw.procIDEnvKey,
+			ProcID:                    runnerProcID,
+		}
+		runnerInstance, err := runnerBuilder.Build(runnerDescription)
+		if err != nil {
+			logger.Error(err, "Error creating runner")
+			os.Exit(1)
+		}
+
+		// If this process belongs to a test process chain, override the logged test index in order to match its
+		// absolute index among all the test descriptions.
+		if len(description.Tests) == 1 && procIDInfo != nil {
+			testIndex = procIDInfo.testIndex
+		}
+
+		logger := logger.WithValues("testName", testDesc.Name, "testIndex", testIndex)
+
+		logger.Info("Starting test execution...")
+
+		if err := runnerInstance.Run(ctx, testIndex, testDesc); err != nil {
+			var resBuildErr *test.ResourceBuildError
+			var stepBuildErr *test.StepBuildError
+			var resCreationErr *test.ResourceCreationError
+			var stepRunErr *test.StepBuildError
+
+			switch {
+			case errors.As(err, &resBuildErr):
+				logger.Error(resBuildErr.Err, "Error building test resource", "resourceName", resBuildErr.ResourceName,
+					"resourceIndex", resBuildErr.ResourceIndex)
+			case errors.As(err, &stepBuildErr):
+				logger.Error(stepBuildErr.Err, "Error building test step", "stepName", stepBuildErr.StepName,
+					"stepIndex", stepBuildErr.StepIndex)
+			case errors.As(err, &resCreationErr):
+				logger.Error(resCreationErr.Err, "Error creating test resource", "resourceName",
+					resCreationErr.ResourceName, "resourceIndex", resCreationErr.ResourceIndex)
+			case errors.As(err, &stepRunErr):
+				logger.Error(stepRunErr.Err, "Error running test step", "stepName", stepRunErr.StepName, "stepIndex",
+					stepRunErr.StepIndex)
+			default:
+				logger.Error(err, "Error running test")
+			}
+
+			os.Exit(1)
+		}
+
+		logger.Info("Test execution completed")
+	}
+}
+
+// buildRunnerEnviron creates a list of string representing the environment, by adding to the current process
+// environment all the provided command flags and all the required environment variable needed to enable the runner to
+// rerun the current executable with the proper environment configuration.
+func (cw *CommandWrapper) buildRunnerEnviron(c *cobra.Command) []string {
+	environ := os.Environ()
+	environ = cw.appendFlags(environ, c.PersistentFlags(), c.Flags())
+	environ = append(environ, fmt.Sprintf("%s=1", cw.declarativeEnvKey))
+	return environ
+}
+
+// appendFlags appends the provided flag sets' flags to environ and returns the updated environ. Works like the builtin
+// append function.
+func (cw *CommandWrapper) appendFlags(environ []string, flagSets ...*pflag.FlagSet) []string {
+	appendFlag := func(flag *pflag.Flag) {
+		keyName := envKeyFromFlagName(cw.envKeysPrefix, flag.Name)
+		environ = append(environ, fmt.Sprintf("%s=%s", keyName, flag.Value.String()))
+	}
+	for _, flagSet := range flagSets {
+		flagSet.VisitAll(appendFlag)
+	}
+	return environ
+}
+
+var (
+	// procIDRegex defines the process ID format and allows to extract the embedded test and child indexes.
+	procIDRegex = regexp.MustCompile(`^test(\d+),child(\d+)$`)
+)
+
+// parseProcID process ID information from the --proc-id flag.
+func parseProcID(flags *pflag.FlagSet) (*processIDInfo, error) {
+	if !flags.Changed(procIDFlagName) {
+		return nil, nil
+	}
+
+	procIDValue, err := flags.GetString(procIDFlagName)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving %q flag: %w", procIDFlagName, err)
+	}
+
+	match := procIDRegex.FindStringSubmatch(procIDValue)
+	if match == nil {
+		return nil, fmt.Errorf("process ID must comply with %q regex", procIDRegex.String())
+	}
+
+	// No errors can occur, since we have already verified through regex that they are numbers.
+	testIndex, _ := strconv.Atoi(match[1])
+	childIndex, _ := strconv.Atoi(match[2])
+
+	parts := strings.Split(procIDValue, ",")
+
+	procID := &processIDInfo{
+		testName:   parts[0],
+		testIndex:  testIndex,
+		childName:  parts[1],
+		childIndex: childIndex,
+	}
+
+	return procID, nil
+}
+
+// loadTestsDescription loads the YAML tests description from a different source, depending on the provided flags. If
+// the --description-file flag is provided, the description is loaded from the specified file; if the --description flag
+// is provided, the description is loaded from the flag argument; otherwise, it is loaded from standard input.
+func loadTestsDescription(logger logr.Logger, flags *pflag.FlagSet) (*loader.Description, error) {
+	ldr := loader.New()
+
+	if flags.Changed(descriptionFileFlagName) {
+		descriptionFilePath, err := flags.GetString(descriptionFileFlagName)
+		if err != nil {
+			return nil, fmt.Errorf("error retrieving %q flag: %w", descriptionFileFlagName, err)
+		}
+
+		descriptionFilePath = filepath.Clean(descriptionFilePath)
+		descriptionFile, err := os.Open(descriptionFilePath)
+		if err != nil {
+			return nil, fmt.Errorf("error opening description file %q: %w", descriptionFilePath, err)
+		}
+		defer func() {
+			if err := descriptionFile.Close(); err != nil {
+				logger.Error(err, "Error closing description file", "path", descriptionFilePath)
+			}
+		}()
+
+		return ldr.Load(descriptionFile)
+	}
+
+	if flags.Changed(descriptionFlagName) {
+		description, err := flags.GetString(descriptionFlagName)
+		if err != nil {
+			return nil, fmt.Errorf("error retrieving %q flag: %w", descriptionFlagName, err)
+		}
+
+		return ldr.Load(strings.NewReader(description))
+	}
+
+	return ldr.Load(os.Stdin)
+}

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/dustin/go-humanize v1.0.1
 	github.com/falcosecurity/client-go v0.6.1
 	github.com/go-logr/logr v1.4.2
+	github.com/go-logr/zapr v1.3.0
 	github.com/go-playground/locales v0.14.1
 	github.com/go-playground/universal-translator v0.18.1
 	github.com/go-playground/validator/v10 v10.22.1
@@ -19,6 +20,7 @@ require (
 	github.com/spf13/viper v1.19.0
 	github.com/stretchr/testify v1.9.0
 	github.com/vishvananda/netlink v1.3.0
+	go.uber.org/zap v1.26.0
 	golang.org/x/sys v0.26.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/apimachinery v0.31.1

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,8 @@ github.com/go-errors/errors v1.5.1 h1:ZwEMSLRCapFLflTpT7NKaAc7ukJ8ZPEjzlxt8rPN8b
 github.com/go-errors/errors v1.5.1/go.mod h1:sIVyrIiJhuEF+Pj9Ebtd6P/rEYROXFi3BopGUQ5a5Og=
 github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=
 github.com/go-logr/logr v1.4.2/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
+github.com/go-logr/zapr v1.3.0 h1:XGdV8XW8zdwFiwOA2Dryh1gj2KRQyOOoNmBy4EplIcQ=
+github.com/go-logr/zapr v1.3.0/go.mod h1:YKepepNBd1u/oyhd/yQmtjVXmm9uML4IXUgMOwR8/Gg=
 github.com/go-openapi/jsonpointer v0.21.0 h1:YgdVicSA9vH5RiHs9TZW5oyafXZFc6+2Vc1rr/O9oNQ=
 github.com/go-openapi/jsonpointer v0.21.0/go.mod h1:IUyH9l/+uyhIYQ/PXVA41Rexl+kOkAPDdXEYns6fzUY=
 github.com/go-openapi/jsonreference v0.21.0 h1:Rs+Y7hSXT83Jacb7kFyjn4ijOuVGSvOdF2+tg1TRrwQ=
@@ -192,6 +194,8 @@ go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
 go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
+go.uber.org/zap v1.26.0 h1:sI7k6L95XOKS281NhVKOFCUNIvv9e0w4BF8N3u+tCRo=
+go.uber.org/zap v1.26.0/go.mod h1:dtElttAiwGvoJ/vj4IwHBS/gXsEu/pZ50mUIRWuG0so=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=

--- a/pkg/log/doc.go
+++ b/pkg/log/doc.go
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2024 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package log provides logging capability. It exports two loggers: DefaultLogger and Logger. DefaultLogger must only be
+// used before having initialized Logger through InitLogger.
+package log

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2024 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/go-logr/zapr"
+	uzap "go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+var (
+	// DefaultLogger is initialized at startup time and must only be used by any package that wants to produce log lines
+	// before Logger is initialized through InitLogger.
+	DefaultLogger = getProductionLogger()
+	// Logger is the main exported logger. It must be initialized through InitLogger.
+	Logger logr.Logger
+)
+
+// Profile is the logging profile.
+type Profile string
+
+const (
+	// ProfileProduction denotes a production-grade logger.
+	ProfileProduction Profile = "prod"
+	// ProfileDevelopment denotes a logger useful during the developing phase.
+	ProfileDevelopment Profile = "dev"
+)
+
+// InitLogger initialized the global Logger instance.
+func InitLogger(profile Profile) error {
+	switch profile {
+	case ProfileProduction:
+		Logger = getProductionLogger()
+	case ProfileDevelopment:
+		Logger = getDevelopmentLogger()
+	default:
+		return fmt.Errorf("unknown profile %q", profile)
+	}
+	return nil
+}
+
+// getProductionLogger returns a production-grade logger.
+func getProductionLogger() logr.Logger {
+	encoderConfig := uzap.NewProductionEncoderConfig()
+	encoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
+	encoderConfig.EncodeCaller = zapcore.FullCallerEncoder
+	jsonEncoder := zapcore.NewJSONEncoder(encoderConfig)
+
+	level := uzap.NewAtomicLevelAt(zapcore.InfoLevel)
+	cores := []zapcore.Core{
+		zapcore.NewCore(jsonEncoder, os.Stderr, level),
+	}
+	tee := zapcore.NewTee(cores...)
+
+	options := []uzap.Option{
+		uzap.ErrorOutput(os.Stderr),
+		uzap.AddCaller(),
+		uzap.AddStacktrace(uzap.ErrorLevel),
+		uzap.WrapCore(func(core zapcore.Core) zapcore.Core {
+			return zapcore.NewSamplerWithOptions(core, time.Second, 100, 100)
+		}),
+	}
+	logger := uzap.New(tee, options...)
+	return zapr.NewLogger(logger)
+}
+
+// getDevelopmentLogger returns a logger useful during the developing phase.
+func getDevelopmentLogger() logr.Logger {
+	encoderConfig := uzap.NewDevelopmentEncoderConfig()
+	encoderConfig.EncodeLevel = zapcore.LowercaseColorLevelEncoder
+	encoderConfig.EncodeTime = zapcore.ISO8601TimeEncoder
+	encoderConfig.EncodeCaller = zapcore.FullCallerEncoder
+	consoleEncoder := zapcore.NewConsoleEncoder(encoderConfig)
+	level := uzap.NewAtomicLevelAt(zapcore.DebugLevel)
+	cores := []zapcore.Core{
+		zapcore.NewCore(consoleEncoder, os.Stderr, level),
+	}
+	tee := zapcore.NewTee(cores...)
+	options := []uzap.Option{
+		uzap.ErrorOutput(os.Stderr),
+		uzap.Development(),
+		uzap.AddCaller(),
+		uzap.AddStacktrace(uzap.WarnLevel),
+	}
+	logger := uzap.New(tee, options...)
+	return zapr.NewLogger(logger)
+}

--- a/pkg/test/loader/doc.go
+++ b/pkg/test/loader/doc.go
@@ -13,5 +13,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package loader defines a Loader, able to unmarshall a YAML document into a Configuration.
+// Package loader defines a Loader, able to unmarshall a YAML document into a Description.
 package loader

--- a/pkg/test/loader/loader.go
+++ b/pkg/test/loader/loader.go
@@ -134,7 +134,7 @@ type Test struct {
 	BeforeScript   *string            `yaml:"before,omitempty" validate:"omitempty,min=1"`
 	AfterScript    *string            `yaml:"after,omitempty" validate:"omitempty,min=1"`
 	Resources      []TestResource     `yaml:"resources,omitempty" validate:"omitempty,unique=Name,dive"`
-	Steps          []TestStep         `yaml:"steps" validate:"min=1,unique=Name,dive"`
+	Steps          []TestStep         `yaml:"steps,omitempty" validate:"omitempty,unique=Name,dive"`
 	ExpectedOutput TestExpectedOutput `yaml:"expectedOutput"`
 }
 

--- a/pkg/test/loader/loader.go
+++ b/pkg/test/loader/loader.go
@@ -25,7 +25,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// Loader loads tests configurations.
+// Loader loads tests descriptions.
 type Loader struct{}
 
 // New creates a new Loader.
@@ -33,41 +33,41 @@ func New() *Loader {
 	return &Loader{}
 }
 
-// Load loads the configuration from the provided reader.
-func (l *Loader) Load(r io.Reader) (*Configuration, error) {
+// Load loads the description from the provided reader.
+func (l *Loader) Load(r io.Reader) (*Description, error) {
 	dec := yaml.NewDecoder(r)
 	// Force the decoding to fail if the YAML document contains unknown fields
 	dec.KnownFields(true)
-	conf := &Configuration{}
-	if err := dec.Decode(conf); err != nil {
-		return nil, fmt.Errorf("error decoding configuration: %w", err)
+	desc := &Description{}
+	if err := dec.Decode(desc); err != nil {
+		return nil, fmt.Errorf("error decoding description: %w", err)
 	}
 
-	if err := conf.validate(); err != nil {
-		return nil, fmt.Errorf("error validating configuration: %w", err)
+	if err := desc.validate(); err != nil {
+		return nil, fmt.Errorf("error validating description: %w", err)
 	}
 
-	return conf, nil
+	return desc, nil
 }
 
-// Configuration contains the description of the tests.
-type Configuration struct {
+// Description contains the description of the tests.
+type Description struct {
 	Tests []Test `yaml:"tests" validate:"min=1,unique=Name,dive"`
 }
 
-// Write writes the configuration to the provided writer.
-func (c *Configuration) Write(w io.Writer) error {
+// Write writes the description to the provided writer.
+func (c *Description) Write(w io.Writer) error {
 	enc := yaml.NewEncoder(w)
 	if err := enc.Encode(c); err != nil {
-		return fmt.Errorf("error encoding configuration: %w", err)
+		return fmt.Errorf("error encoding description: %w", err)
 	}
 
 	return nil
 }
 
-// validate validates the current configuration.
-func (c *Configuration) validate() error {
-	// Register custom validations and validate configuration
+// validate validates the current description.
+func (c *Description) validate() error {
+	// Register custom validations and validate description
 	validate := validator.New(validator.WithRequiredStructEnabled())
 	if err := registerValidations(validate); err != nil {
 		return fmt.Errorf("error registering validations: %w", err)
@@ -124,7 +124,7 @@ func validateRuleName(fl validator.FieldLevel) bool {
 	return ruleNameRegex.MatchString(field.String())
 }
 
-// Test is a rule test configuration.
+// Test is a rule test description.
 type Test struct {
 	Rule           string             `yaml:"rule" validate:"rule_name"`
 	Name           string             `yaml:"name" validate:"required"`

--- a/pkg/test/runner/builder/builder.go
+++ b/pkg/test/runner/builder/builder.go
@@ -52,7 +52,7 @@ func (b *builder) Build(description *runner.Description) (runner.Runner, error) 
 			logger,
 			b.testBuilder,
 			description.Environ,
-			description.TestConfigEnvKey,
+			description.TestDescriptionEnvKey,
 			description.ProcIDEnvKey,
 			description.ProcID,
 		)

--- a/pkg/test/runner/builder/builder.go
+++ b/pkg/test/runner/builder/builder.go
@@ -53,6 +53,7 @@ func (b *builder) Build(description *runner.Description) (runner.Runner, error) 
 			b.testBuilder,
 			description.Environ,
 			description.TestDescriptionEnvKey,
+			description.TestDescriptionFileEnvKey,
 			description.ProcIDEnvKey,
 			description.ProcID,
 		)

--- a/pkg/test/runner/runner.go
+++ b/pkg/test/runner/runner.go
@@ -43,8 +43,9 @@ type Description struct {
 	Type loader.TestRunnerType
 	// Environ is a list of strings representing the environment, in the form "key=value".
 	Environ []string
-	// TestConfigEnvKey is the key identifying the environment variable used to store the serialized test configuration.
-	TestConfigEnvKey string
+	// TestDescriptionEnvKey is the key identifying the environment variable used to store the serialized test
+	// description.
+	TestDescriptionEnvKey string
 	// ProcIDEnvKey is the key identifying the environment variable used to store the process identifier in the form
 	// "test<testIndex>,child<childIndex>".
 	ProcIDEnvKey string

--- a/pkg/test/runner/runner.go
+++ b/pkg/test/runner/runner.go
@@ -46,6 +46,9 @@ type Description struct {
 	// TestDescriptionEnvKey is the key identifying the environment variable used to store the serialized test
 	// description.
 	TestDescriptionEnvKey string
+	// TestDescriptionFileEnvKey is the key identifying the environment variable used to store path of the file
+	// containing the serialized test description.
+	TestDescriptionFileEnvKey string
 	// ProcIDEnvKey is the key identifying the environment variable used to store the process identifier in the form
 	// "test<testIndex>,child<childIndex>".
 	ProcIDEnvKey string

--- a/pkg/test/step/syscall/base/parse.go
+++ b/pkg/test/step/syscall/base/parse.go
@@ -64,7 +64,7 @@ func parseOpenHow(value string) (*unix.OpenHow, error) {
 		Resolve string `yaml:"resolve"`
 	}
 	if err := dec.Decode(&openHowView); err != nil {
-		return nil, fmt.Errorf("error decoding configuration: %w", err)
+		return nil, fmt.Errorf("error decoding: %w", err)
 	}
 
 	openHow := &unix.OpenHow{}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note: it's really useful for the changelog!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind documentation

> /kind tests

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area commands

/area pkg

> /area events

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR introduces the `declarative` commands namespace and the `declarative run` subcommand to enable users to run tests via a YAML description of them.
It also introduces a new `log` package, leveraging `logr` and the `zap` logger, that is going to replace the actual `logrus` logger in the future. However, for the moment, it lets `logrus` and `logr` coexists until is decided to completely replace `logrus` with `logr`. 
Finally, it enable support for providing an empty test step list, since some rules can be triggered even without performing any step (i.e. by creating specific resources and/or by creating a specific process chain).

The following is YAML description sample that can be passed to the CLI to test its behaviour:
```
tests:
  - rule: StdoutStdinToNetworkConnection
    name: test1
    description: "Redirect stdout/stdin to network connection"
    runner: HostRunner
    context:
      processes:
        - exePath: "/tmp/parent"
          args: "-a -b -c" # these are argv[1], argv[2], etc...; if unspecified default to ""
          exe: "arv0" # this is argv[0]; if unspecified, defaults to name if this is specified, to base("/path/to/exe") otherwise.
          name: "procName" # this is the process name; if unspecified, defaults to base("/path/to/exe")
        - exePath: "/tmp/child"
    before: |
      echo "Hi!"
    resources:
      - type: clientServer
        name: cs1
        l4Proto: tcp4
        address: 11.0.0.1:80
    steps:
      - type: syscall
        name: dup1
        syscall: dup2
        args:
          oldfd: "${cs1.client.fd}"
          newfd: 0
    after: |
      echo "Bye!"
```
It creates a process chain composed of a `parent` and a `child` (it tunes the `parent` process and its command configuration in order to demonstrate what can be achieved). The last process (i.e. the `child` process) in the chain is the one that will run the "before" and "after" scripts and will create the specified resources and steps.
The `clientServer` test resource allows to spawn a `tcp4` server listening on `11.0.0.1:80`. It also spawns a client that is automatically connected to the server. This resources exposes both the client and the server sockets file descriptors as bindable fields.
The `syscall` test step performs a `dup2` system call and binds the process stdin file descriptor to the the client socket file descriptor. It performs this task by leveraging the field binding feature.

Supposing the aforementioned YAML is stored in the file `sample.yaml` of the current working directory, the test can be run by issuing the following command:
```
sudo <event_generator_exepath> declarative run --description-file sample.yaml
```

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

