### PR TITLE
fix(decl): use SetUint for open_mode uint32 field

### DIFF
--- a/pkg/test/step/syscall/base/base.go
+++ b/pkg/test/step/syscall/base/base.go
@@ -58,6 +58,8 @@ type baseSyscall struct {
 // Verify that baseSyscall implements syscall.Syscall interface.
 var _ syscall.Syscall = (*baseSyscall)(nil)
 
+var errOpenModeMustBePositive = fmt.Errorf("open mode must be a positive integer")
+
 // New creates a new generic system call test step.
 func New(stepName string, rawArgs map[string]string, fieldBindings []*step.FieldBinding, argsContainer,
 	bindOnlyArgsContainer, retValueContainer reflect.Value, defaultedArgs []string,
@@ -172,6 +174,9 @@ func setArgFieldValue(argField *field.Field, value string) error {
 		openMode, err := parseFlags(value, openModes)
 		if err != nil {
 			return fmt.Errorf("cannot parse value as open mode: %w", err)
+		}
+		if openMode < 0 {
+			return errOpenModeMustBePositive
 		}
 		argFieldValue.SetUint(uint64(openMode))
 	case field.TypeOpenHow:

--- a/pkg/test/step/syscall/base/base.go
+++ b/pkg/test/step/syscall/base/base.go
@@ -173,7 +173,7 @@ func setArgFieldValue(argField *field.Field, value string) error {
 		if err != nil {
 			return fmt.Errorf("cannot parse value as open mode: %w", err)
 		}
-		argFieldValue.SetInt(int64(openMode))
+		argFieldValue.SetUint(uint64(openMode))
 	case field.TypeOpenHow:
 		openHow, err := parseOpenHow(value)
 		if err != nil {


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note: it's really useful for the changelog!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind documentation

> /kind tests

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area commands

/area pkg

> /area events

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

The issue can be reproduced with the following test:

```
tests:
  - rule: DirectoryTraversalMonitoredFileRead
    name: test2
    runner: HostRunner
    before: "echo Hi"
    steps:
      - type: syscall
        name: open
        syscall: open
        args:
          pathname: "/etc/../etc/../etc/shadow"
          flags: 0
          mode: 0644
    after: "echo Bye"
```

It was crashing with:

```
panic: reflect: call of reflect.Value.SetInt on uint32 Value
```

After this fix it runs successfully:
```
2024-11-10T23:22:23.483+0100	info	root	/Users/jose.calvo/repos/event-generator/cmd/declarative/run/run.go:221	Starting test execution...	{"testName": "test2", "testIndex": 0}
2024-11-10T23:22:23.494+0100	info	root.runner.test.script	/Users/jose.calvo/repos/event-generator/pkg/test/script/shell/shell.go:174	Script log line	{"runnerType": "HostRunner", "testName": "test2", "testIndex": 0, "type": "stdout", "line": "Hi"}
2024-11-10T23:22:23.504+0100	debug	root.runner.test	/Users/jose.calvo/repos/event-generator/pkg/test/test/test.go:142	Executed test step	{"runnerType": "HostRunner", "testName": "test2", "testIndex": 0, "stepName": "open", "stepIndex": 0}
2024-11-10T23:22:23.510+0100	debug	root.runner.test	/Users/jose.calvo/repos/event-generator/pkg/test/test/test.go:187	Executed test step cleanup	{"runnerType": "HostRunner", "testName": "test2", "testIndex": 0, "stepName": "open", "stepIndex": 0}
2024-11-10T23:22:23.511+0100	info	root.runner.test.script	/Users/jose.calvo/repos/event-generator/pkg/test/script/shell/shell.go:174	Script log line	{"runnerType": "HostRunner", "testName": "test2", "testIndex": 0, "type": "stdout", "line": "Bye"}
2024-11-10T23:22:23.514+0100	info	root	/Users/jose.calvo/repos/event-generator/cmd/declarative/run/run.go:249	Test execution completed	{"testName": "test2", "testIndex": 0}
```

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

