### PR TITLE
feat(decl): add test command support

### DIFF
--- a/cmd/declarative/config/config.go
+++ b/cmd/declarative/config/config.go
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2024 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	// DescriptionFileFlagName is the name of the flag allowing to specify the path of the file containing the YAML
+	// tests description.
+	DescriptionFileFlagName = "description-file"
+	// DescriptionFlagName is the name of the flag allowing to specify the YAML tests description.
+	DescriptionFlagName = "description"
+	// TestIDFlagName is the name of the flag allowing to specify the test identifier.
+	TestIDFlagName = "test-id"
+	// ProcLabelFlagName is the name of the flag allowing to specify a process label.
+	ProcLabelFlagName = "proc-label"
+	// TimeoutFlagName is the name of the flag allowing to specify the test timeout.
+	TimeoutFlagName = "timeout"
+)
+
+// Config represents the configuration shared among declarative commands. Among other shared settings, it also stores
+// the values of the shared flags.
+type Config struct {
+	EnvKeysPrefix     string
+	DeclarativeEnvKey string
+	// DescriptionFileEnvKey is the environment variable key corresponding to DescriptionFileFlagName.
+	DescriptionFileEnvKey string
+	// DescriptionEnvKey is the environment variable key corresponding to DescriptionFlagName.
+	DescriptionEnvKey string
+	// TestIDEnvKey is the environment variable key corresponding to TestIDFlagName.
+	TestIDEnvKey string
+	// ProcLabelEnvKey is the environment variable key corresponding to ProcLabelFlagName.
+	ProcLabelEnvKey string
+	// TimeoutEnvKey is the environment variable key corresponding to TimeoutFlagName.
+	TimeoutEnvKey string
+
+	// Flags
+	//
+	// TestsDescriptionFile is the path of the file containing the YAML tests description. If testsDescription is
+	// provided, this is empty.
+	TestsDescriptionFile string
+	// TestsDescription is the YAML tests description. If TestsDescriptionFile is provided, this is empty.
+	TestsDescription string
+	// TestID is the test identifier in the form [testIDIgnorePrefix]<testUID>. It is used to propagate the test UID to
+	// child processes in the process chain. The following invariants hold:
+	// - the root process has no test ID
+	// - the processes in the process chain but the last have the test ID in the form testIDIgnorePrefix<testUID>
+	// - the last process in the process chain has the test ID in the form <testUID>
+	// A process having a test ID in the form <testUID> (i.e.: the leaf process) is the only one that is monitored.
+	TestID string
+	//  ProcLabel is the process label in the form test<testIndex>.child<childIndex>. It is used for logging purposes
+	// and to potentially generate the child process label.
+	ProcLabel string
+	// TestsTimeout is the maximal duration of the tests. If running tests lasts more than TestsTimeout, the execution
+	// of all pending tasks is canceled.
+	TestsTimeout time.Duration
+}
+
+// New creates a new config linked to the provided command.
+func New(cmd *cobra.Command, declarativeEnvKey, envKeysPrefix string) *Config {
+	commonConf := &Config{
+		DeclarativeEnvKey:     declarativeEnvKey,
+		EnvKeysPrefix:         envKeysPrefix,
+		DescriptionFileEnvKey: envKeyFromFlagName(envKeysPrefix, DescriptionFileFlagName),
+		DescriptionEnvKey:     envKeyFromFlagName(envKeysPrefix, DescriptionFlagName),
+		TestIDEnvKey:          envKeyFromFlagName(envKeysPrefix, TestIDFlagName),
+		ProcLabelEnvKey:       envKeyFromFlagName(envKeysPrefix, ProcLabelFlagName),
+		TimeoutEnvKey:         envKeyFromFlagName(envKeysPrefix, TimeoutFlagName),
+	}
+	commonConf.initFlags(cmd)
+	return commonConf
+}
+
+// initFlags initializes the provided command's flags and uses the config instance to store the flag bound values.
+func (c *Config) initFlags(cmd *cobra.Command) {
+	flags := cmd.PersistentFlags()
+
+	flags.StringVarP(&c.TestsDescriptionFile, DescriptionFileFlagName, "f", "",
+		"The tests description YAML file specifying the tests to be run")
+	flags.StringVarP(&c.TestsDescription, DescriptionFlagName, "d", "",
+		"The YAML-formatted tests description string specifying the tests to be run")
+	cmd.MarkFlagsMutuallyExclusive(DescriptionFileFlagName, DescriptionFlagName)
+
+	flags.StringVar(&c.TestID, TestIDFlagName, "",
+		"(used during process chain building) The test identifier in the form <ignorePrefix><testUID>. It is "+
+			"used to propagate the test UID to child processes in the process chain")
+	flags.StringVar(&c.ProcLabel, ProcLabelFlagName, "",
+		"(used during process chain building) The process label in the form test<testIndex>,child<childIndex>. "+
+			"It is used for logging purposes and to potentially generate the child process label")
+	_ = flags.MarkHidden(TestIDFlagName)
+	_ = flags.MarkHidden(ProcLabelFlagName)
+
+	flags.DurationVarP(&c.TestsTimeout, TimeoutFlagName, "t", time.Minute,
+		"The maximal duration of the tests. If running tests lasts more than testsTimeout, the execution of "+
+			"all pending tasks is canceled")
+}
+
+// envKeyFromFlagName converts the provided flag name into the corresponding environment variable key.
+func envKeyFromFlagName(envKeysPrefix, flagName string) string {
+	s := fmt.Sprintf("%s_%s", envKeysPrefix, strings.ToUpper(flagName))
+	s = strings.ToUpper(s)
+	return strings.ReplaceAll(s, "-", "_")
+}

--- a/cmd/declarative/config/doc.go
+++ b/cmd/declarative/config/doc.go
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2024 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package config provides the implementation of Config, the configuration shared among declarative commands. Among
+// other shared settings, it also stores the values of the shared flags.
+package config

--- a/cmd/declarative/declarative.go
+++ b/cmd/declarative/declarative.go
@@ -18,7 +18,9 @@ package declarative
 import (
 	"github.com/spf13/cobra"
 
+	"github.com/falcosecurity/event-generator/cmd/declarative/config"
 	"github.com/falcosecurity/event-generator/cmd/declarative/run"
+	"github.com/falcosecurity/event-generator/cmd/declarative/test"
 )
 
 // New creates a new declarative command.
@@ -30,7 +32,11 @@ func New(declarativeEnvKey, envKeysPrefix string) *cobra.Command {
 		DisableAutoGenTag: true,
 	}
 
-	c.AddCommand(run.New(declarativeEnvKey, envKeysPrefix).Command)
+	commonConf := config.New(c, declarativeEnvKey, envKeysPrefix)
 
+	runCmd := run.New(declarativeEnvKey, envKeysPrefix).Command
+	testCmd := test.New(commonConf, false).Command
+	c.AddCommand(runCmd)
+	c.AddCommand(testCmd)
 	return c
 }

--- a/cmd/declarative/declarative.go
+++ b/cmd/declarative/declarative.go
@@ -34,7 +34,7 @@ func New(declarativeEnvKey, envKeysPrefix string) *cobra.Command {
 
 	commonConf := config.New(c, declarativeEnvKey, envKeysPrefix)
 
-	runCmd := run.New(declarativeEnvKey, envKeysPrefix).Command
+	runCmd := run.New(commonConf)
 	testCmd := test.New(commonConf, false).Command
 	c.AddCommand(runCmd)
 	c.AddCommand(testCmd)

--- a/cmd/declarative/run/run.go
+++ b/cmd/declarative/run/run.go
@@ -232,9 +232,20 @@ func (cw *CommandWrapper) run(c *cobra.Command, _ []string) {
 
 		var testUID string
 		if isRootProcess {
+			// Generate a new uid for the test.
 			testUID = uuid.New().String()
 			testID = fmt.Sprintf("%s%s", testIDIgnorePrefix, testUID)
+
+			// Ensure the process chain has at least one element. If the user didn't specify anything, add a default
+			// process to the chain.
+			if testDesc.Context == nil {
+				testDesc.Context = &loader.TestContext{}
+			}
+			if len(testDesc.Context.Processes) == 0 {
+				testDesc.Context.Processes = []loader.ProcessContext{{}}
+			}
 		} else {
+			// Extract uid from test id.
 			testUID = strings.TrimPrefix(testID, testIDIgnorePrefix)
 		}
 

--- a/cmd/declarative/test/doc.go
+++ b/cmd/declarative/test/doc.go
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2024 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package test provides the implementation of the "test" command. This command lets users run tests and verify their
+// outcomes by providing a YAML description of them containing their expected outcomes.
+package test

--- a/cmd/declarative/test/test.go
+++ b/cmd/declarative/test/test.go
@@ -1,0 +1,458 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2024 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/google/uuid"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+
+	"github.com/falcosecurity/event-generator/cmd/declarative/config"
+	"github.com/falcosecurity/event-generator/pkg/alert/retriever/grpcretriever"
+	"github.com/falcosecurity/event-generator/pkg/test"
+	testbuilder "github.com/falcosecurity/event-generator/pkg/test/builder"
+	"github.com/falcosecurity/event-generator/pkg/test/loader"
+	resbuilder "github.com/falcosecurity/event-generator/pkg/test/resource/builder"
+	"github.com/falcosecurity/event-generator/pkg/test/runner"
+	runnerbuilder "github.com/falcosecurity/event-generator/pkg/test/runner/builder"
+	stepbuilder "github.com/falcosecurity/event-generator/pkg/test/step/builder"
+	sysbuilder "github.com/falcosecurity/event-generator/pkg/test/step/syscall/builder"
+	"github.com/falcosecurity/event-generator/pkg/test/tester"
+	"github.com/falcosecurity/event-generator/pkg/test/tester/reportencoder/textencoder"
+	testerimpl "github.com/falcosecurity/event-generator/pkg/test/tester/tester"
+)
+
+const (
+	// testIDIgnorePrefix is the prefix used to mark a process as not monitored.
+	testIDIgnorePrefix = "ignore:"
+)
+
+const (
+	longDescriptionPrefaceTemplate = `%s.
+It is possible to provide the YAML description in multiple ways. The order of evaluation is the following:
+1) If the --%s=<file_path> flag is provided the description is read from the file at <file_path>
+2) If the --%s=<description> flag is provided, the description is read from the <description> string
+3) Otherwise, it is read from standard input`
+	longDescriptionHeading = "Run test(s) specified via a YAML description and verify that they produce the expected outcomes"
+	warningMessage         = `ReportWarning:
+  This command might alter your system. For example, some actions modify files and directories below /bin, /etc, /dev,
+  etc... Make sure you fully understand what is the purpose of this tool before running any action.`
+)
+
+// CommandWrapper is a wrapper around the test command storing the flag values bound to the command at runtime.
+type CommandWrapper struct {
+	*config.Config
+	Command                 *cobra.Command
+	skipOutcomeVerification bool
+	unixSocketPath          string
+	hostname                string
+	port                    uint16
+	certFile                string
+	keyFile                 string
+	caRootFile              string
+	pollingTimeout          time.Duration
+}
+
+var (
+	longDescriptionPreface = fmt.Sprintf(longDescriptionPrefaceTemplate, longDescriptionHeading,
+		config.DescriptionFileFlagName, config.DescriptionFlagName)
+	longDescription = fmt.Sprintf("%s\n\n%s", longDescriptionPreface, warningMessage)
+)
+
+// New creates a new test command.
+func New(commonConf *config.Config, skipOutcomesVerification bool) *CommandWrapper {
+	cw := &CommandWrapper{Config: commonConf, skipOutcomeVerification: skipOutcomesVerification}
+
+	c := &cobra.Command{
+		Use:               "test",
+		Short:             longDescriptionHeading,
+		Long:              longDescription,
+		DisableAutoGenTag: true,
+		Run:               cw.run,
+	}
+
+	cw.initFlags(c)
+
+	cw.Command = c
+	return cw
+}
+
+// initFlags initializes the provided command's flags.
+func (cw *CommandWrapper) initFlags(c *cobra.Command) {
+	if cw.skipOutcomeVerification {
+		return
+	}
+
+	flags := c.Flags()
+
+	flags.BoolVar(&cw.skipOutcomeVerification, "skip-outcome-verification", false,
+		"Skip verification of the expected outcome. If this option is enabled, grpc- flags are ignored")
+	flags.StringVar(&cw.unixSocketPath, "grpc-unix-socket", "",
+		"The unix socket path of the local Falco instance (use only if you want to connect to Falco through a "+
+			"unix socket)")
+	flags.StringVar(&cw.hostname, "grpc-hostname", "localhost",
+		"The Falco gRPC server hostname")
+	flags.Uint16Var(&cw.port, "grpc-port", 5060, "The Falco gRPC server port")
+	flags.StringVar(&cw.certFile, "grpc-cert", "/etc/falco/certs/client.crt",
+		"The path of the client certificate to be used for mutual TLS against the Falco gRPC server")
+	flags.StringVar(&cw.keyFile, "grpc-key", "/etc/falco/certs/client.key",
+		"The path of the client private key to be used for mutual TLS against the Falco gRPC server")
+	flags.StringVar(&cw.caRootFile, "grpc-ca", "/etc/falco/certs/ca.crt",
+		"The path of the CA root certificate used for Falco gRPC server's certificate validation")
+	flags.DurationVar(&cw.pollingTimeout, "grpc-poll-timeout", 100*time.Millisecond,
+		"The frequency of the watch operation on the gRPC Falco Outputs API stream")
+}
+
+// envKeyFromFlagName converts the provided flag name into the corresponding environment variable key.
+func envKeyFromFlagName(envKeysPrefix, flagName string) string {
+	s := fmt.Sprintf("%s_%s", envKeysPrefix, strings.ToUpper(flagName))
+	s = strings.ToUpper(s)
+	return strings.ReplaceAll(s, "-", "_")
+}
+
+// run runs the provided command with the provided arguments.
+func (cw *CommandWrapper) run(cmd *cobra.Command, _ []string) {
+	ctx := cmd.Context()
+	logger, err := logr.FromContext(ctx)
+	if err != nil {
+		panic(fmt.Sprintf("logger unconfigured: %v", err))
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, cw.TestsTimeout)
+	defer cancel()
+	exitAndCancel := func() {
+		cancel()
+		os.Exit(1)
+	}
+
+	// Retrieve the already populated test ID. The test ID absence is used to uniquely identify the root process in the
+	// process chain.
+	testID := cw.TestID
+	isRootProcess := testID == ""
+
+	procLabelInfo, err := parseProcLabel(cw.ProcLabel)
+	if err != nil {
+		logger.Error(err, "Error parsing process label")
+		exitAndCancel()
+	}
+
+	if procLabelInfo == nil {
+		logger = logger.WithName("root")
+	} else {
+		logger = logger.WithName(procLabelInfo.testName).WithName(procLabelInfo.childName)
+	}
+
+	description, err := loadTestsDescription(logger, cw.TestsDescriptionFile, cw.TestsDescription)
+	if err != nil {
+		logger.Error(err, "Error loading tests description")
+		exitAndCancel()
+	}
+
+	resourceBuilder, err := resbuilder.New()
+	if err != nil {
+		logger.Error(err, "Error creating resource builder")
+		exitAndCancel()
+	}
+
+	syscallBuilder := sysbuilder.New()
+	stepBuilder, err := stepbuilder.New(syscallBuilder)
+	if err != nil {
+		logger.Error(err, "Error creating step builder")
+		exitAndCancel()
+	}
+
+	testBuilder, err := testbuilder.New(resourceBuilder, stepBuilder)
+	if err != nil {
+		logger.Error(err, "Error creating test builder")
+		exitAndCancel()
+	}
+
+	runnerBuilder, err := runnerbuilder.New(testBuilder)
+	if err != nil {
+		logger.Error(err, "Error creating runner builder")
+		exitAndCancel()
+	}
+
+	var testr tester.Tester
+	if isRootProcess && !cw.skipOutcomeVerification {
+		if testr, err = cw.initTester(logger); err != nil {
+			logger.Error(err, "Error initializing tester")
+			exitAndCancel()
+		}
+	}
+
+	testerWaitGroup := sync.WaitGroup{}
+	if testr != nil {
+		go func() {
+			if err := testr.StartAlertsCollection(ctx); err != nil {
+				logger.Error(err, "Error starting tester execution")
+				exitAndCancel()
+			}
+		}()
+	}
+
+	// Prepare parameters shared by runners.
+	runnerLogger := logger.WithName("runner")
+	runnerEnviron := cw.buildRunnerEnviron(cmd)
+	var runnerProcLabel string
+	if procLabelInfo != nil {
+		runnerProcLabel = fmt.Sprintf("%s,%s", procLabelInfo.testName, procLabelInfo.childName)
+	}
+
+	// Build and run the tests.
+	for testIndex := range description.Tests {
+		testDesc := &description.Tests[testIndex]
+
+		logger := logger.WithValues("testName", testDesc.Name, "testIndex", testIndex)
+
+		var testUID uuid.UUID
+		if isRootProcess {
+			// Generate a new UID for the test.
+			testUID = uuid.New()
+			testID = fmt.Sprintf("%s%s", testIDIgnorePrefix, testUID.String())
+
+			// Ensure the process chain has at least one element. If the user didn't specify anything, add a default
+			// process to the chain.
+			if testDesc.Context == nil {
+				testDesc.Context = &loader.TestContext{}
+			}
+			if len(testDesc.Context.Processes) == 0 {
+				testDesc.Context.Processes = []loader.ProcessContext{{}}
+			}
+		} else {
+			// Extract UID from test ID.
+			var err error
+			testUID, err = uuid.Parse(strings.TrimPrefix(testID, testIDIgnorePrefix))
+			if err != nil {
+				logger.Error(err, "Error parsing test UID", "testUid")
+				exitAndCancel()
+			}
+		}
+
+		logger = logger.WithValues("testUid", testUID)
+
+		runnerDescription := &runner.Description{
+			Environ:                   runnerEnviron,
+			TestDescriptionEnvKey:     cw.DescriptionEnvKey,
+			TestDescriptionFileEnvKey: cw.DescriptionFileEnvKey,
+			TestIDEnvKey:              cw.TestIDEnvKey,
+			TestIDIgnorePrefix:        testIDIgnorePrefix,
+			ProcLabelEnvKey:           cw.ProcLabelEnvKey,
+			ProcLabel:                 runnerProcLabel,
+		}
+		runnerInstance, err := runnerBuilder.Build(testDesc.Runner, runnerLogger, runnerDescription)
+		if err != nil {
+			logger.Error(err, "Error creating runner")
+			exitAndCancel()
+		}
+
+		// If this process belongs to a test process chain, override the logged test index in order to match its
+		// absolute index among all the test descriptions.
+		if !isRootProcess {
+			testIndex = procLabelInfo.testIndex
+		}
+
+		logger.Info("Starting test execution...")
+
+		if err := runnerInstance.Run(ctx, testID, testIndex, testDesc); err != nil {
+			var resBuildErr *test.ResourceBuildError
+			var stepBuildErr *test.StepBuildError
+			var resCreationErr *test.ResourceCreationError
+			var stepRunErr *test.StepBuildError
+
+			switch {
+			case errors.As(err, &resBuildErr):
+				logger.Error(resBuildErr.Err, "Error building test resource", "resourceName", resBuildErr.ResourceName,
+					"resourceIndex", resBuildErr.ResourceIndex)
+			case errors.As(err, &stepBuildErr):
+				logger.Error(stepBuildErr.Err, "Error building test step", "stepName", stepBuildErr.StepName,
+					"stepIndex", stepBuildErr.StepIndex)
+			case errors.As(err, &resCreationErr):
+				logger.Error(resCreationErr.Err, "Error creating test resource", "resourceName",
+					resCreationErr.ResourceName, "resourceIndex", resCreationErr.ResourceIndex)
+			case errors.As(err, &stepRunErr):
+				logger.Error(stepRunErr.Err, "Error running test step", "stepName", stepRunErr.StepName, "stepIndex",
+					stepRunErr.StepIndex)
+			default:
+				logger.Error(err, "Error running test")
+			}
+
+			exitAndCancel()
+		}
+
+		logger.Info("Test execution completed")
+
+		if testr != nil {
+			produceReport(&testerWaitGroup, testr, &testUID, testDesc)
+		}
+	}
+
+	testerWaitGroup.Wait()
+}
+
+var (
+	// procLabelRegex defines the process label format and allows to extract the embedded test and child indexes.
+	procLabelRegex    = regexp.MustCompile(`^test(\d+),child(\d+)$`)
+	errProcLabelRegex = fmt.Errorf("process label must comply with %q regex", procLabelRegex.String())
+)
+
+// processLabelInfo contains information regarding the process label.
+type processLabelInfo struct {
+	testName   string
+	testIndex  int
+	childName  string
+	childIndex int
+}
+
+// parseProcLabel parses the process label and returns information on it.
+func parseProcLabel(procLabel string) (*processLabelInfo, error) {
+	if procLabel == "" {
+		return nil, nil
+	}
+
+	match := procLabelRegex.FindStringSubmatch(procLabel)
+	if match == nil {
+		return nil, errProcLabelRegex
+	}
+
+	// No errors can occur, since we have already verified through regex that they are numbers.
+	testIndex, _ := strconv.Atoi(match[1])
+	childIndex, _ := strconv.Atoi(match[2])
+
+	parts := strings.Split(procLabel, ",")
+
+	procLabelInfo := &processLabelInfo{
+		testName:   parts[0],
+		testIndex:  testIndex,
+		childName:  parts[1],
+		childIndex: childIndex,
+	}
+
+	return procLabelInfo, nil
+}
+
+// loadTestsDescription loads the YAML tests description from a different source, depending on the content of the
+// provided values:
+// - if the provided descriptionFilePath is not empty, the description is loaded from the specified file
+// - if the provided description is not empty, the description is loaded from its content
+// - otherwise, it is loaded from standard input.
+func loadTestsDescription(logger logr.Logger, descriptionFilePath, description string) (*loader.Description, error) {
+	ldr := loader.New()
+
+	if descriptionFilePath != "" {
+		descriptionFilePath = filepath.Clean(descriptionFilePath)
+		descriptionFile, err := os.Open(descriptionFilePath)
+		if err != nil {
+			return nil, fmt.Errorf("error opening description file %q: %w", descriptionFilePath, err)
+		}
+		defer func() {
+			if err := descriptionFile.Close(); err != nil {
+				logger.Error(err, "Error closing description file", "path", descriptionFilePath)
+			}
+		}()
+
+		return ldr.Load(descriptionFile)
+	}
+
+	if description != "" {
+		return ldr.Load(strings.NewReader(description))
+	}
+
+	return ldr.Load(os.Stdin)
+}
+
+func (cw *CommandWrapper) initTester(logger logr.Logger) (tester.Tester, error) {
+	gRPCRetrieverOptions := []grpcretriever.Option{
+		grpcretriever.WithUnixSocketPath(cw.unixSocketPath),
+		grpcretriever.WithHostname(cw.hostname),
+		grpcretriever.WithPort(cw.port),
+		grpcretriever.WithCertFile(cw.certFile),
+		grpcretriever.WithKeyFile(cw.keyFile),
+		grpcretriever.WithCARootFile(cw.caRootFile),
+		grpcretriever.WithPollingTimeout(cw.pollingTimeout),
+	}
+	grpcRetriever, err := grpcretriever.New(logger, gRPCRetrieverOptions...)
+	if err != nil {
+		return nil, fmt.Errorf("error creating gRPC retriever: %w", err)
+	}
+
+	t := testerimpl.New(grpcRetriever, cw.TestIDEnvKey, testIDIgnorePrefix)
+	return t, nil
+}
+
+// buildRunnerEnviron creates a list of strings representing the environment, by adding to the current process
+// environment all the provided command flags and all the required environment variable needed to enable the runner to
+// rerun the current executable with the proper environment configuration.
+func (cw *CommandWrapper) buildRunnerEnviron(cmd *cobra.Command) []string {
+	environ := os.Environ()
+	environ = cw.appendFlags(environ, cmd.PersistentFlags(), cmd.Flags())
+	environ = append(environ, fmt.Sprintf("%s=1", cw.DeclarativeEnvKey))
+	return environ
+}
+
+// appendFlags appends the provided flag sets' flags to environ and returns the updated environ. Works like the builtin
+// append function.
+func (cw *CommandWrapper) appendFlags(environ []string, flagSets ...*pflag.FlagSet) []string {
+	appendFlag := func(flag *pflag.Flag) {
+		keyName := envKeyFromFlagName(cw.EnvKeysPrefix, flag.Name)
+		environ = append(environ, fmt.Sprintf("%s=%s", keyName, flag.Value.String()))
+	}
+	for _, flagSet := range flagSets {
+		flagSet.VisitAll(appendFlag)
+	}
+	return environ
+}
+
+// produceReport produces a report for the given test by using the provided tester.
+func produceReport(wg *sync.WaitGroup, testr tester.Tester, testUID *uuid.UUID, testDesc *loader.Test) {
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		testName, ruleName := testDesc.Name, testDesc.Rule
+		report := getReport(testr, testUID, ruleName, &testDesc.ExpectedOutcome)
+		report.TestName, report.RuleName = testName, ruleName
+		// TODO: perform error checking
+		_ = textencoder.New(os.Stdout).Encode(report)
+	}()
+}
+
+// getReport retrieves a report for the provided test and rule by leveraging the provided tester.
+func getReport(testr tester.Tester, uid *uuid.UUID, rule string,
+	expectedOutcome *loader.TestExpectedOutcome) *tester.Report {
+	time.Sleep(1 * time.Second)
+	for i := 0; i < 3; i++ {
+		report := testr.Report(uid, rule, expectedOutcome)
+		if !report.Empty() {
+			return report
+		}
+
+		time.Sleep((4 / (1 << i)) * time.Second)
+	}
+
+	return testr.Report(uid, rule, expectedOutcome)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -63,6 +63,7 @@ func New(configOptions *ConfigOptions) *cobra.Command {
 		Use:               "event-generator",
 		Short:             "A command line tool to perform a variety of suspect actions.",
 		DisableAutoGenTag: true,
+		TraverseChildren:  true,
 		PersistentPreRun: func(c *cobra.Command, args []string) {
 			// PersistentPreRun runs before flags validation but after args validation.
 			// Do not assume initialization completed during args validation.

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/go-playground/locales v0.14.1
 	github.com/go-playground/universal-translator v0.18.1
 	github.com/go-playground/validator/v10 v10.22.1
+	github.com/google/uuid v1.6.0
 	github.com/iancoleman/strcase v0.3.0
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/prometheus/procfs v0.15.1
@@ -64,7 +65,6 @@ require (
 	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/gregjones/httpcache v0.0.0-20190611155906-901d90724c79 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect

--- a/pkg/alert/alert.go
+++ b/pkg/alert/alert.go
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2024 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package alert
+
+import (
+	"context"
+)
+
+// Retriever allows to retrieve a stream of Falco alerts.
+type Retriever interface {
+	// AlertStream returns a channel that can be used to consume a stream of Falco alerts. The returned channel is
+	// closed if the provided context is canceled.
+	AlertStream(ctx context.Context) (<-chan *Alert, error)
+}
+
+// Alert is a Falco alert.
+type Alert struct {
+	Priority     Priority
+	Rule         string
+	OutputFields map[string]string
+	Hostname     string
+	Source       string
+}
+
+// Priority is priority associated with an alert.
+type Priority string
+
+const (
+	// PriorityEmergency defines the emergency priority value.
+	PriorityEmergency Priority = "emergency"
+	// PriorityAlert defines the alert priority value.
+	PriorityAlert Priority = "alert"
+	// PriorityCritical defines the critical priority value.
+	PriorityCritical Priority = "critical"
+	// PriorityError defines the error priority value.
+	PriorityError Priority = "error"
+	// PriorityWarning defines the warning priority value.
+	PriorityWarning Priority = "warning"
+	// PriorityNotice defines the notice priority value.
+	PriorityNotice Priority = "notice"
+	// PriorityInformational defines the informational priority value.
+	PriorityInformational Priority = "informational"
+	// PriorityDebug defines the debug priority value.
+	PriorityDebug Priority = "debug"
+)

--- a/pkg/alert/doc.go
+++ b/pkg/alert/doc.go
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2024 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package alert provides the definition of an Alert and an alert Retriever.
+package alert

--- a/pkg/alert/retriever/grpcretriever/doc.go
+++ b/pkg/alert/retriever/grpcretriever/doc.go
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2024 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package grpcretriever provides an implementation of alert.Retriever leveraging the gPRC Falco Outputs API.
+package grpcretriever

--- a/pkg/alert/retriever/grpcretriever/grpcretriever.go
+++ b/pkg/alert/retriever/grpcretriever/grpcretriever.go
@@ -1,0 +1,225 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2024 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package grpcretriever
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	outputspb "github.com/falcosecurity/client-go/pkg/api/outputs"
+	schemapb "github.com/falcosecurity/client-go/pkg/api/schema"
+	"github.com/falcosecurity/client-go/pkg/client"
+	"github.com/go-logr/logr"
+
+	"github.com/falcosecurity/event-generator/pkg/alert"
+)
+
+// config stores the gRPC retriever underlying configuration.
+type config struct {
+	unixSocketPath string
+	hostname       string
+	port           uint16
+	certFile       string
+	keyFile        string
+	caRootFile     string
+	pollingTimeout time.Duration
+}
+
+// Option for configuring the gRPC retriever.
+type Option interface {
+	apply(*config) error
+}
+
+// funcOption is an implementation of Option storing a function that implements the requested apply method behavior.
+type funcOption struct {
+	f func(*config) error
+}
+
+func (cfo *funcOption) apply(c *config) error {
+	return cfo.f(c)
+}
+
+// newFuncOption is a helper function to create a new funcOption from a function.
+func newFuncOption(f func(*config) error) *funcOption {
+	return &funcOption{f: f}
+}
+
+// WithUnixSocketPath allows to specify the unix socket path of the local Falco gRPC server (use only if you want to
+// connect to Falco through a unix socket).
+func WithUnixSocketPath(unixSocketPath string) Option {
+	return newFuncOption(func(c *config) error {
+		c.unixSocketPath = unixSocketPath
+		return nil
+	})
+}
+
+// WithHostname allows to specify the Falco gRPC server hostname.
+func WithHostname(hostname string) Option {
+	return newFuncOption(func(c *config) error {
+		c.hostname = hostname
+		return nil
+	})
+}
+
+// WithPort allows to specify the Falco gRPC server port.
+func WithPort(port uint16) Option {
+	return newFuncOption(func(c *config) error {
+		c.port = port
+		return nil
+	})
+}
+
+// WithCertFile allows to specify the path of the client certificate to be used for mutual TLS against the Falco gRPC
+// server.
+func WithCertFile(certFile string) Option {
+	return newFuncOption(func(c *config) error {
+		c.certFile = certFile
+		return nil
+	})
+}
+
+// WithKeyFile allows to specify the path of the client private key to be used for mutual TLS against the Falco gRPC
+// server.
+func WithKeyFile(keyFile string) Option {
+	return newFuncOption(func(c *config) error {
+		c.keyFile = keyFile
+		return nil
+	})
+}
+
+// WithCARootFile allows to specify the path of the CA root certificate used for Falco gRPC server's certificate
+// validation.
+func WithCARootFile(caRootFile string) Option {
+	return newFuncOption(func(c *config) error {
+		c.caRootFile = caRootFile
+		return nil
+	})
+}
+
+// WithPollingTimeout allows to specify the frequency of the watch operation on the gRPC Falco Outputs API stream.
+func WithPollingTimeout(pollingTimeout time.Duration) Option {
+	return newFuncOption(func(c *config) error {
+		c.pollingTimeout = pollingTimeout
+		return nil
+	})
+}
+
+// gRPCRetriever implements a gRPC alert retriever.
+type gRPCRetriever struct {
+	logger logr.Logger
+	config
+}
+
+// Verify that gRPCRetriever implements alert.Retriever interface.
+var _ alert.Retriever = (*gRPCRetriever)(nil)
+
+var defaultConfig = &config{
+	unixSocketPath: "",
+	hostname:       "localhost",
+	port:           5060,
+	certFile:       "/etc/falco/certs/client.crt",
+	keyFile:        "/etc/falco/certs/client.key",
+	caRootFile:     "/etc/falco/certs/ca.crt",
+	pollingTimeout: 100 * time.Millisecond,
+}
+
+// New creates a new gRPC alert retriever and configures it with the provided options.
+func New(logger logr.Logger, options ...Option) (alert.Retriever, error) {
+	r := &gRPCRetriever{
+		logger: logger,
+		config: *defaultConfig,
+	}
+
+	for _, opt := range options {
+		if err := opt.apply(&r.config); err != nil {
+			return nil, fmt.Errorf("error applying option: %w", err)
+		}
+	}
+
+	return r, nil
+}
+
+func (r *gRPCRetriever) AlertStream(ctx context.Context) (<-chan *alert.Alert, error) {
+	conf := client.Config{
+		Hostname:       r.hostname,
+		Port:           r.port,
+		CertFile:       r.certFile,
+		KeyFile:        r.keyFile,
+		CARootFile:     r.caRootFile,
+		UnixSocketPath: r.unixSocketPath,
+	}
+	falcoClient, err := client.NewForConfig(ctx, &conf)
+	if err != nil {
+		return nil, fmt.Errorf("error creating new Falco client: %w", err)
+	}
+
+	outputs, err := falcoClient.Outputs()
+	if err != nil {
+		return nil, fmt.Errorf("error getting client for Falco Outputs API: %w", err)
+	}
+
+	stream, err := outputs.Sub(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("error subscribing to Falco Outputs API stream: %w", err)
+	}
+
+	return r.alertStream(ctx, stream), nil
+}
+
+// alertStream returns a channel that can be used to consume a stream of Falco alerts. The returned channel is closed if
+// the provided context is canceled.
+func (r *gRPCRetriever) alertStream(ctx context.Context, stream outputspb.Service_SubClient) <-chan *alert.Alert {
+	alertCh := make(chan *alert.Alert)
+	go func() {
+		defer close(alertCh)
+		if err := client.OutputsWatch(ctx, stream, func(res *outputspb.Response) error {
+			logger := r.logger.WithValues("rule", res.Rule, "source", res.Source, "priority", res.Priority, "hostname",
+				res.Hostname)
+			logger.V(1).Info("Received alert")
+			priority := res.Priority
+			priorityName, ok := schemapb.Priority_name[int32(priority)]
+			if !ok {
+				logger.Info("Received alert with unknown priority", "priority", priority)
+				return nil
+			}
+
+			alrt := &alert.Alert{
+				Priority:     alert.Priority(strings.ToLower(priorityName)),
+				Rule:         res.Rule,
+				OutputFields: res.OutputFields,
+				Hostname:     res.Hostname,
+				Source:       res.Source,
+			}
+
+			select {
+			case <-ctx.Done():
+			case alertCh <- alrt:
+				logger.V(1).Info("Sent alert downstream")
+			}
+
+			return nil
+		}, r.pollingTimeout); err != nil && !errors.Is(err, ctx.Err()) {
+			r.logger.Error(err, "Error getting alert from Falco Outputs API stream")
+		} else {
+			r.logger.V(1).Info("Read from Falco Outputs API stream stopped")
+		}
+	}()
+
+	return alertCh
+}

--- a/pkg/random/doc.go
+++ b/pkg/random/doc.go
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2024 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package random defines utility functions to generate random objects.
+package random

--- a/pkg/random/random.go
+++ b/pkg/random/random.go
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2024 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package random
+
+import (
+	"crypto/rand"
+	"math/big"
+)
+
+var letters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+
+// Seq generates a random sequence of length n.
+func Seq(n int) string {
+	b := make([]rune, n)
+	lettersLen := len(letters)
+	for i := range b {
+		letterIndex, _ := rand.Int(rand.Reader, big.NewInt(int64(lettersLen)))
+		b[i] = letters[letterIndex.Int64()]
+	}
+	return string(b)
+}

--- a/pkg/test/loader/loader.go
+++ b/pkg/test/loader/loader.go
@@ -126,16 +126,16 @@ func validateRuleName(fl validator.FieldLevel) bool {
 
 // Test is a rule test description.
 type Test struct {
-	Rule           string             `yaml:"rule" validate:"rule_name"`
-	Name           string             `yaml:"name" validate:"required"`
-	Description    *string            `yaml:"description,omitempty" validate:"omitempty,min=1"`
-	Runner         TestRunnerType     `yaml:"runner" validate:"-"`
-	Context        *TestContext       `yaml:"context,omitempty" validate:"omitempty"`
-	BeforeScript   *string            `yaml:"before,omitempty" validate:"omitempty,min=1"`
-	AfterScript    *string            `yaml:"after,omitempty" validate:"omitempty,min=1"`
-	Resources      []TestResource     `yaml:"resources,omitempty" validate:"omitempty,unique=Name,dive"`
-	Steps          []TestStep         `yaml:"steps,omitempty" validate:"omitempty,unique=Name,dive"`
-	ExpectedOutput TestExpectedOutput `yaml:"expectedOutput"`
+	Rule            string              `yaml:"rule" validate:"rule_name"`
+	Name            string              `yaml:"name" validate:"required"`
+	Description     *string             `yaml:"description,omitempty" validate:"omitempty,min=1"`
+	Runner          TestRunnerType      `yaml:"runner" validate:"-"`
+	Context         *TestContext        `yaml:"context,omitempty" validate:"omitempty"`
+	BeforeScript    *string             `yaml:"before,omitempty" validate:"omitempty,min=1"`
+	AfterScript     *string             `yaml:"after,omitempty" validate:"omitempty,min=1"`
+	Resources       []TestResource      `yaml:"resources,omitempty" validate:"omitempty,unique=Name,dive"`
+	Steps           []TestStep          `yaml:"steps,omitempty" validate:"omitempty,unique=Name,dive"`
+	ExpectedOutcome TestExpectedOutcome `yaml:"expectedOutcome"`
 }
 
 // TestRunnerType is the type of test runner.
@@ -722,8 +722,8 @@ func (s *SyscallName) UnmarshalYAML(node *yaml.Node) error {
 	return nil
 }
 
-// TestExpectedOutput is the expected output for a test.
-type TestExpectedOutput struct {
+// TestExpectedOutcome is the expected outcome for a test.
+type TestExpectedOutcome struct {
 	Source       *string           `yaml:"source,omitempty" validate:"omitempty,min=1"`
 	Time         *string           `yaml:"time,omitempty" validate:"omitempty,min=1"`
 	Hostname     *string           `yaml:"hostname,omitempty" validate:"omitempty,min=1"`

--- a/pkg/test/loader/loader.go
+++ b/pkg/test/loader/loader.go
@@ -178,16 +178,16 @@ type ContainerContext struct {
 // ProcessContext contains information regarding the process that will run a test, or information about one of its
 // ancestors.
 type ProcessContext struct {
-	// ExePath is the executable path.
-	ExePath string `yaml:"exePath" validate:"required"`
+	// ExePath is the executable path. If omitted, it is randomly generated.
+	ExePath *string `yaml:"exePath" validate:"omitempty,min=1"`
 	// Args is a string containing the space-separated list of command line arguments. If a single argument contains
-	// spaces, the entire argument must be quoted in order to not be considered as multiple arguments. If omitted or
-	// empty, it defaults to "".
+	// spaces, the entire argument must be quoted in order to not be considered as multiple arguments. If omitted, it
+	// defaults to "".
 	Args *string `yaml:"args,omitempty" validate:"omitempty,min=1"`
-	// Exe is the argument in position 0 (a.k.a. argv[0]) of the process. If omitted or empty, it defaults to Name if
-	// this is specified; otherwise, it defaults to filepath.Base(ExePath).
+	// Exe is the argument in position 0 (a.k.a. argv[0]) of the process. If omitted, it defaults to Name if this is
+	// specified; otherwise, it defaults to filepath.Base(ExePath).
 	Exe *string `yaml:"exe,omitempty" validate:"omitempty,min=1"`
-	// Name is the process name. If omitted or empty, it defaults to filepath.Base(ExePath).
+	// Name is the process name. If omitted, it defaults to filepath.Base(ExePath).
 	Name *string `yaml:"name,omitempty" validate:"omitempty,min=1"`
 	// Env is the set of environment variables that must be provided to the process (in addition to the default ones).
 	Env map[string]string `yaml:"env,omitempty" validate:"omitempty,min=1"`

--- a/pkg/test/loader/loader.go
+++ b/pkg/test/loader/loader.go
@@ -725,9 +725,7 @@ func (s *SyscallName) UnmarshalYAML(node *yaml.Node) error {
 // TestExpectedOutcome is the expected outcome for a test.
 type TestExpectedOutcome struct {
 	Source       *string           `yaml:"source,omitempty" validate:"omitempty,min=1"`
-	Time         *string           `yaml:"time,omitempty" validate:"omitempty,min=1"`
 	Hostname     *string           `yaml:"hostname,omitempty" validate:"omitempty,min=1"`
 	Priority     *string           `yaml:"priority,omitempty" validate:"omitempty,min=1"`
-	Output       *string           `yaml:"output,omitempty" validate:"omitempty,min=1"`
 	OutputFields map[string]string `yaml:"outputFields,omitempty" validate:"omitempty,min=1"`
 }

--- a/pkg/test/loader/loader.go
+++ b/pkg/test/loader/loader.go
@@ -18,7 +18,6 @@ package loader
 import (
 	"fmt"
 	"io"
-	"reflect"
 	"regexp"
 
 	"github.com/go-playground/validator/v10"
@@ -67,12 +66,8 @@ func (c *Description) Write(w io.Writer) error {
 
 // validate validates the current description.
 func (c *Description) validate() error {
-	// Register custom validations and validate description
+	// Validate declaratively the description.
 	validate := validator.New(validator.WithRequiredStructEnabled())
-	if err := registerValidations(validate); err != nil {
-		return fmt.Errorf("error registering validations: %w", err)
-	}
-
 	if err := validate.Struct(c); err != nil {
 		return err
 	}
@@ -101,32 +96,9 @@ func validateNameUniqueness(test *Test) error {
 	return nil
 }
 
-const validationTagRuleName = "rule_name"
-
-var ruleNameRegex = regexp.MustCompile(`^[a-zA-Z0-9_-]{8,64}$`)
-
-// registerValidations registers custom validations.
-func registerValidations(validate *validator.Validate) error {
-	if err := validate.RegisterValidation(validationTagRuleName, validateRuleName); err != nil {
-		return fmt.Errorf("cannot register validation for tag %q: %w", validationTagRuleName, err)
-	}
-
-	return nil
-}
-
-// validateRuleName flags a field as valid if it matches ruleNameRegexString.
-func validateRuleName(fl validator.FieldLevel) bool {
-	field := fl.Field()
-	if field.Kind() != reflect.String {
-		return false
-	}
-
-	return ruleNameRegex.MatchString(field.String())
-}
-
 // Test is a rule test description.
 type Test struct {
-	Rule            string              `yaml:"rule" validate:"rule_name"`
+	Rule            string              `yaml:"rule" validate:"required"`
 	Name            string              `yaml:"name" validate:"required"`
 	Description     *string             `yaml:"description,omitempty" validate:"omitempty,min=1"`
 	Runner          TestRunnerType      `yaml:"runner" validate:"-"`

--- a/pkg/test/runner/builder/builder.go
+++ b/pkg/test/runner/builder/builder.go
@@ -18,6 +18,8 @@ package builder
 import (
 	"fmt"
 
+	"github.com/go-logr/logr"
+
 	"github.com/falcosecurity/event-generator/pkg/test"
 	"github.com/falcosecurity/event-generator/pkg/test/loader"
 	"github.com/falcosecurity/event-generator/pkg/test/runner"
@@ -43,20 +45,12 @@ func New(testBuilder test.Builder) (runner.Builder, error) {
 	return b, nil
 }
 
-func (b *builder) Build(description *runner.Description) (runner.Runner, error) {
-	runnerType := description.Type
-	logger := description.Logger.WithValues("runnerType", runnerType)
+func (b *builder) Build(runnerType loader.TestRunnerType, logger logr.Logger,
+	description *runner.Description) (runner.Runner, error) {
+	logger = logger.WithValues("runnerType", runnerType)
 	switch runnerType {
 	case loader.TestRunnerTypeHost:
-		return host.New(
-			logger,
-			b.testBuilder,
-			description.Environ,
-			description.TestDescriptionEnvKey,
-			description.TestDescriptionFileEnvKey,
-			description.ProcLabelEnvKey,
-			description.ProcLabel,
-		)
+		return host.New(logger, b.testBuilder, description)
 	default:
 		return nil, fmt.Errorf("unknown test runner type %q", runnerType)
 	}

--- a/pkg/test/runner/builder/builder.go
+++ b/pkg/test/runner/builder/builder.go
@@ -54,8 +54,8 @@ func (b *builder) Build(description *runner.Description) (runner.Runner, error) 
 			description.Environ,
 			description.TestDescriptionEnvKey,
 			description.TestDescriptionFileEnvKey,
-			description.ProcIDEnvKey,
-			description.ProcID,
+			description.ProcLabelEnvKey,
+			description.ProcLabel,
 		)
 	default:
 		return nil, fmt.Errorf("unknown test runner type %q", runnerType)

--- a/pkg/test/runner/runner.go
+++ b/pkg/test/runner/runner.go
@@ -26,21 +26,17 @@ import (
 // Runner allows to run a test.
 type Runner interface {
 	// Run runs the provided test.
-	Run(ctx context.Context, testIndex int, test *loader.Test) error
+	Run(ctx context.Context, testID string, testIndex int, test *loader.Test) error
 }
 
 // Builder allows to build a new test runner.
 type Builder interface {
 	// Build builds a new test runner using the provided description.
-	Build(description *Description) (Runner, error)
+	Build(runnerType loader.TestRunnerType, logger logr.Logger, description *Description) (Runner, error)
 }
 
 // Description contains information to build a new test runner.
 type Description struct {
-	// Logger is the test runner logger.
-	Logger logr.Logger
-	// Type is the test runner type.
-	Type loader.TestRunnerType
 	// Environ is a list of strings representing the environment, in the form "key=value".
 	Environ []string
 	// TestDescriptionEnvKey is the key identifying the environment variable used to store the serialized test
@@ -49,6 +45,11 @@ type Description struct {
 	// TestDescriptionFileEnvKey is the key identifying the environment variable used to store path of the file
 	// containing the serialized test description.
 	TestDescriptionFileEnvKey string
+	// TestIDEnvKey is the key identifying the environment variable used to store the test identifier in the form
+	// [<ignorePrefix>]<testUID>.
+	TestIDEnvKey string
+	// TestIDIgnorePrefix is the optional testID prefix value.
+	TestIDIgnorePrefix string
 	// ProcLabelEnvKey is the key identifying the environment variable used to store the process label in the form
 	// "test<testIndex>,child<childIndex>".
 	ProcLabelEnvKey string

--- a/pkg/test/runner/runner.go
+++ b/pkg/test/runner/runner.go
@@ -49,9 +49,9 @@ type Description struct {
 	// TestDescriptionFileEnvKey is the key identifying the environment variable used to store path of the file
 	// containing the serialized test description.
 	TestDescriptionFileEnvKey string
-	// ProcIDEnvKey is the key identifying the environment variable used to store the process identifier in the form
+	// ProcLabelEnvKey is the key identifying the environment variable used to store the process label in the form
 	// "test<testIndex>,child<childIndex>".
-	ProcIDEnvKey string
-	// ProcID is the current process ID.
-	ProcID string
+	ProcLabelEnvKey string
+	// ProcLabel is the current process label.
+	ProcLabel string
 }

--- a/pkg/test/tester/doc.go
+++ b/pkg/test/tester/doc.go
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2024 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package tester provides the definition of test Tester, tester Report and ReportEncoder. A Tester allows to verify
+// that the running tests produce the expected outcomes. A Tester produces a Report for a given test. A ReportEncoder
+// can be used to encode and write the report to some destination.
+package tester

--- a/pkg/test/tester/reportencoder/textencoder/doc.go
+++ b/pkg/test/tester/reportencoder/textencoder/doc.go
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2024 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package textencoder provides an implementation of tester.ReportEncoder allowing to write a report to the underlying
+// destination using a formatted text encoding.
+package textencoder

--- a/pkg/test/tester/reportencoder/textencoder/textencoder.go
+++ b/pkg/test/tester/reportencoder/textencoder/textencoder.go
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2024 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package textencoder
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/falcosecurity/event-generator/pkg/test/tester"
+)
+
+// textEncoder is an implementation of tester.ReportEncoder allowing to write a report to the underlying destination
+// using a formatted text encoding.
+type textEncoder struct {
+	writer io.Writer
+}
+
+// Verify that textEncoder implements tester.ReportEncoder interface.
+var _ tester.ReportEncoder = (*textEncoder)(nil)
+
+// New creates a new report text-formatting encoder.
+func New(w io.Writer) tester.ReportEncoder {
+	te := &textEncoder{writer: w}
+	return te
+}
+
+func (te *textEncoder) Encode(report *tester.Report) error {
+	sb := strings.Builder{}
+	sb.WriteString(fmt.Sprintf("Test %s, Rule %s\n", report.TestName, report.RuleName))
+
+	if report.Empty() {
+		sb.WriteString("\tFailed")
+		_, err := io.WriteString(te.writer, sb.String())
+		return err
+	}
+
+	sb.WriteString(fmt.Sprintf("\tSuccessful matches: %d\n", report.SuccessfulMatches))
+	sb.WriteString(fmt.Sprintf("\tGenerated warnings: %d\n", len(report.GeneratedWarnings)))
+
+	for warningIndex := range report.GeneratedWarnings {
+		warning := &report.GeneratedWarnings[warningIndex]
+		sb.WriteString(fmt.Sprintf("\t\tWarning %d\n", warningIndex))
+		for fieldWarningIndex := range warning.FieldWarnings {
+			fieldWarning := &warning.FieldWarnings[fieldWarningIndex]
+			sb.WriteString(fmt.Sprintf("\t\t\tField: %s, Expected: %v, Got: %v\n", fieldWarning.Field,
+				fieldWarning.Expected, fieldWarning.Got))
+		}
+	}
+
+	_, err := io.WriteString(te.writer, sb.String())
+	return err
+}

--- a/pkg/test/tester/tester.go
+++ b/pkg/test/tester/tester.go
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2024 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tester
+
+import (
+	"context"
+
+	"github.com/google/uuid"
+
+	"github.com/falcosecurity/event-generator/pkg/test/loader"
+)
+
+// Tester allows to verify that the running tests produce the expected outcomes.
+type Tester interface {
+	// StartAlertsCollection starts the process of alerts collection.
+	StartAlertsCollection(ctx context.Context) error
+	// Report returns a report containing information regarding the alerts matching or not matching the provided
+	// expected outcome for the provided rule.
+	Report(uid *uuid.UUID, rule string, expectedOutcome *loader.TestExpectedOutcome) *Report
+}
+
+// A Report contains information regarding the successful matches and generated warning for given test testing a given
+// rule.
+type Report struct {
+	TestName          string
+	RuleName          string
+	SuccessfulMatches int
+	GeneratedWarnings []ReportWarning
+}
+
+// Empty reports if the report specifies no successful matches and no generated warning.
+func (r *Report) Empty() bool {
+	return r.SuccessfulMatches == 0 && len(r.GeneratedWarnings) == 0
+}
+
+// A ReportWarning is associated to a received alert matching a rule, but having some fields not matching the expected
+// outcome definition.
+type ReportWarning struct {
+	FieldWarnings []ReportFieldWarning
+}
+
+// ReportFieldWarning contains information regarding an expected outcome field, its expected value and the value
+// contained in the alert.
+type ReportFieldWarning struct {
+	Field    string
+	Expected any
+	Got      any
+}
+
+// ReportEncoder allows to encode a report.
+type ReportEncoder interface {
+	// Encode encodes the provided report with a specific format and write it to the underlying destination.
+	Encode(report *Report) error
+}

--- a/pkg/test/tester/tester/doc.go
+++ b/pkg/test/tester/tester/doc.go
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2024 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package tester provides an implementation of tester.Tester.
+package tester

--- a/pkg/test/tester/tester/tester.go
+++ b/pkg/test/tester/tester/tester.go
@@ -1,0 +1,233 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2024 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tester
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/google/uuid"
+
+	"github.com/falcosecurity/event-generator/pkg/alert"
+	"github.com/falcosecurity/event-generator/pkg/test/loader"
+	"github.com/falcosecurity/event-generator/pkg/test/tester"
+)
+
+// testImpl is an implementation of tester.Tester.
+type testerImpl struct {
+	alertRetriever        alert.Retriever
+	testIDEnvVarPrefix    string
+	testIDEnvVarPrefixLen int
+	testIDIgnorePrefix    string
+	testIDIgnorePrefixLen int
+
+	sync.Mutex
+	uidToAlerts map[uuid.UUID][]*alert.Alert
+}
+
+// Verify that testerImpl implements tester.Tester interface.
+var _ tester.Tester = (*testerImpl)(nil)
+
+// New creates a new tester.
+func New(alertRetriever alert.Retriever, testIDEnvKey, testIDIgnorePrefix string) tester.Tester {
+	testIDEnvVarPrefix := testIDEnvKey + "="
+	testIDEnvVarPrefixLen := len(testIDEnvVarPrefix)
+	t := &testerImpl{
+		alertRetriever:        alertRetriever,
+		testIDEnvVarPrefix:    testIDEnvVarPrefix,
+		testIDEnvVarPrefixLen: testIDEnvVarPrefixLen,
+		testIDIgnorePrefix:    testIDIgnorePrefix,
+		testIDIgnorePrefixLen: len(testIDIgnorePrefix),
+		uidToAlerts:           make(map[uuid.UUID][]*alert.Alert),
+	}
+	return t
+}
+
+func (t *testerImpl) StartAlertsCollection(ctx context.Context) error {
+	alertCh, err := t.alertRetriever.AlertStream(ctx)
+	if err != nil {
+		return fmt.Errorf("error creating alert stream: %w", err)
+	}
+
+	alertInfoCh := t.filterAlertsWithUID(ctx, alertCh)
+	t.startAlertsCaching(ctx, alertInfoCh)
+	return nil
+}
+
+// alertInfo associated an alert with the corresponding test UID.
+type alertInfo struct {
+	uid   *uuid.UUID
+	alert *alert.Alert
+}
+
+// filterAlertsWithUID asynchronously reads from the provided alerts channel and only produces, on the returned channel,
+// the alerts containing a test UID.
+func (t *testerImpl) filterAlertsWithUID(ctx context.Context, alertCh <-chan *alert.Alert) <-chan *alertInfo {
+	alertInfoCh := make(chan *alertInfo)
+	go func() {
+		defer close(alertInfoCh)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case alrt, ok := <-alertCh:
+				if !ok {
+					return
+				}
+
+				uid := t.findUID(alrt)
+				if uid == nil {
+					continue
+				}
+
+				select {
+				case <-ctx.Done():
+				case alertInfoCh <- &alertInfo{uid: uid, alert: alrt}:
+				}
+			}
+		}
+	}()
+	return alertInfoCh
+}
+
+const (
+	// procEnvFieldName is the name of the alert field containing the process environment variables.
+	procEnvFieldName = "proc.env"
+	// uuidV4Len is the length of the UUIDv4 textual representation (see uuid.Parse implementation).
+	uuidV4Len = 36
+)
+
+// findUID returns the test UID extracted from the provided alert. If test UID is not found, nil is returned.
+func (t *testerImpl) findUID(alrt *alert.Alert) *uuid.UUID {
+	// Retrieve the process environment variables.
+	procEnv, ok := alrt.OutputFields[procEnvFieldName]
+	if !ok {
+		return nil
+	}
+
+	// Search for the environment variable containing the test ID.
+	index := strings.Index(procEnv, t.testIDEnvVarPrefix)
+	if index == -1 {
+		return nil
+	}
+
+	// Remote the environment variable name and verify if the result has the ignore prefix.
+	procEnv = procEnv[index+t.testIDEnvVarPrefixLen:]
+	if strings.HasPrefix(procEnv, t.testIDIgnorePrefix) {
+		return nil
+	}
+
+	// Parse the contained test UID.
+	uid, err := uuid.Parse(procEnv[:uuidV4Len])
+	if err != nil {
+		return nil
+	}
+
+	return &uid
+}
+
+// startAlertsCaching starts caching the alerts received through the provided channel.
+func (t *testerImpl) startAlertsCaching(ctx context.Context, alertInfoCh <-chan *alertInfo) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case info, ok := <-alertInfoCh:
+			if !ok {
+				return
+			}
+			t.cacheAlert(info.uid, info.alert)
+		}
+	}
+}
+
+// cacheAlert insert the provided cache into the underlying cache.
+func (t *testerImpl) cacheAlert(uid *uuid.UUID, alrt *alert.Alert) {
+	t.Lock()
+	defer t.Unlock()
+	t.uidToAlerts[*uid] = append(t.uidToAlerts[*uid], alrt)
+}
+
+func (t *testerImpl) Report(uid *uuid.UUID, rule string, expectedOutcome *loader.TestExpectedOutcome) *tester.Report {
+	t.Lock()
+	defer t.Unlock()
+
+	report := &tester.Report{}
+	alerts, ok := t.uidToAlerts[*uid]
+	if !ok {
+		return report
+	}
+
+	for _, alrt := range alerts {
+		accountAlert(report, rule, alrt, expectedOutcome)
+	}
+
+	return report
+}
+
+// accountAlert accounts the provided alert in the provided report, by matching it against the provided expected outcome
+// for the provided rule.
+func accountAlert(report *tester.Report, reportRule string, alrt *alert.Alert,
+	expectedOutcome *loader.TestExpectedOutcome) {
+	if alrt.Rule != reportRule {
+		return
+	}
+
+	var fieldWarnings []tester.ReportFieldWarning
+
+	if source := expectedOutcome.Source; source != nil && alrt.Source != *source {
+		fieldWarnings = append(fieldWarnings, tester.ReportFieldWarning{
+			Field:    "source",
+			Expected: *source,
+			Got:      alrt.Source,
+		})
+	}
+
+	if hostname := expectedOutcome.Hostname; hostname != nil && alrt.Hostname != *hostname {
+		fieldWarnings = append(fieldWarnings, tester.ReportFieldWarning{
+			Field:    "hostname",
+			Expected: *hostname,
+			Got:      alrt.Hostname,
+		})
+	}
+
+	if priority := expectedOutcome.Priority; priority != nil && string(alrt.Priority) != *priority {
+		fieldWarnings = append(fieldWarnings, tester.ReportFieldWarning{
+			Field:    "priority",
+			Expected: *priority,
+			Got:      alrt.Priority,
+		})
+	}
+
+	for expectedKey, expectedValue := range expectedOutcome.OutputFields {
+		if value, ok := alrt.OutputFields[expectedKey]; !ok || value != expectedValue {
+			fieldWarnings = append(fieldWarnings, tester.ReportFieldWarning{
+				Field:    expectedKey,
+				Expected: expectedValue,
+				Got:      value,
+			})
+		}
+	}
+
+	if len(fieldWarnings) > 0 {
+		report.GeneratedWarnings = append(report.GeneratedWarnings, tester.ReportWarning{FieldWarnings: fieldWarnings})
+		return
+	}
+
+	report.SuccessfulMatches++
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note: it's really useful for the changelog!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind documentation

> /kind tests

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area commands

/area pkg

> /area events

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:
This PR adds the `test` command, that allows to verify that Falco produces the expected alerts as a response to the executed tests. The command allows to connect to Falco via gRPC, through both Unix an AF_INET/AF_INET6 sockets.
The underlying infrastructure has been modified as follows:
- the process chain must be composed at least by one process besides the root process; if no processes are provided in the process chain by the user, a default one is added to it
- test IDs has been added in order to to enable unique identification of the process chain's leaf process. The test ID is stored in the environment of each process chain's process, except the root process. The root process generates a test ID for each test, in the form `<ignorePrefix><testUID>`. Each process in the chain but the one before the leaf passes the untouched test ID to the child. The one before the leaf passes the test ID without the `<ignorePrefix>` to the leaf. In this way, the leaf process is the only one having the test ID equals to `<testUID>`.

The following components have been added:
- alert retriever - collects alerts from Falco (the only available implementation uses gRPC)
- tester - collects alerts from the alert retriever and generates a report

A report is associated with a test (which in turn is associated to a single rule). It contains information regarding (1) the number of alerts successfully matching the expected outcome of the test, and (2) the generated warnings.
A successful match is determined when Falco produces an alert whose fields are equal to the one provided in the expected outcome. 
A warning is associated to a single alert in the context of a rule report. A warning is generated if the alert matches the rule name but doesn't match other expected outcome's fields. In the context of a warning, for each expected outcome's field not matching the alert content, a field warning is generated in the report.
If no successful matches and warning are generated during the alerts inspection time interval for a given test, the test is considered failed.

The warning have been added to take into account possible event drops and consequent `<NA>` values in Falco alerts.

As last features:
- the process chain executable path field is now optional and, if not provided, is automatically generated by the event-generator
- the expected output is now called expected outcome (to distinguish them from Falco outputs)

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

