### PR TITLE
fix(decl): potential nil ptr deref and shell script SIGUSR handling

### DIFF
--- a/pkg/test/loader/loader.go
+++ b/pkg/test/loader/loader.go
@@ -116,6 +116,10 @@ func (t *Test) validateNameUniqueness() error {
 
 // validateContext validates that names used for test resources and steps are unique.
 func (t *Test) validateContext() error {
+	if t.Context == nil {
+		return nil
+	}
+
 	processes := t.Context.Processes
 	processesLen := len(processes)
 	if processesLen <= 1 {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note: it's really useful for the changelog!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind documentation

> /kind tests

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area commands

/area pkg

> /area events

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:
This PR fixes the `SIGUSR1` signal handling for shell scripts by correctly handling the exit code set by the signal (138). The first instruction after the blocking `wait` now verifies the returned exit code and clears its value if it matches the one set by the signal. Moreover, this PR fixes a potential nil pointer dereference in test context validation and conditionally disable shell script execution when both "before" and "after" scripts are not provided by the user.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

