### PR TITLE
fix(decl): fix syscalls argument parsing and cleanup logic 

### DIFF
--- a/pkg/test/field/field.go
+++ b/pkg/test/field/field.go
@@ -61,6 +61,12 @@ const (
 	TypeOpenMode Type = "open_mode"
 	// TypeOpenHow specifies that the field contains the openat2 system call open_how parameter.
 	TypeOpenHow Type = "open_how"
+	// TypeOpenHowFlags specifies that the field contains the openat2 system call open_how flags.
+	TypeOpenHowFlags Type = "open_how_flags"
+	// TypeOpenHowMode specifies that the field contains the openat2 system call open_how mode.
+	TypeOpenHowMode Type = "open_how_mode"
+	// TypeOpenHowResolve specifies that the field contains the openat2 system call open_how resolve value.
+	TypeOpenHowResolve Type = "open_how_resolve"
 	// TypeLinkAtFlags specifies that the field contains the linkat system call flags.
 	TypeLinkAtFlags Type = "linkat_flags"
 	// TypeModuleParams specifies that the field contains the init_module system call params.
@@ -121,7 +127,7 @@ func Paths(fieldContainer reflect.Type) map[string]struct{} {
 		subFieldPaths := Paths(fieldTy)
 		// Generate the complete field path by prefixing, to each subfield, the current field path.
 		for subFieldPath := range subFieldPaths {
-			fieldPaths[fieldPath+fieldPathSegmentsSeparator+subFieldPath] = struct{}{}
+			fieldPaths[JoinFieldPathSegments(fieldPath, subFieldPath)] = struct{}{}
 		}
 	}
 	return fieldPaths
@@ -132,16 +138,21 @@ func Path(s string) string {
 	return strings.ToLower(s)
 }
 
-// splitFieldPath splits the provided field path into multiple segments.
-func splitFieldPath(fieldPath string) []string {
+// splitFieldPathSegments splits the provided field path into multiple segments.
+func splitFieldPathSegments(fieldPath string) []string {
 	return strings.Split(fieldPath, fieldPathSegmentsSeparator)
+}
+
+// JoinFieldPathSegments joins the provided field path segments into a single field path.
+func JoinFieldPathSegments(pathSegments ...string) string {
+	return strings.Join(pathSegments, fieldPathSegmentsSeparator)
 }
 
 // ByName returns information for the field identified by name. The field is searched in the provided fieldContainers,
 // and the first match is returned.
 func ByName(name string, fieldContainers ...reflect.Value) (*Field, error) {
 	fieldPath := Path(name)
-	fieldPathSegments := splitFieldPath(fieldPath)
+	fieldPathSegments := splitFieldPathSegments(fieldPath)
 
 	for _, fieldContainer := range fieldContainers {
 		if field := byName(fieldContainer, fieldPath, fieldPathSegments); field != nil {

--- a/pkg/test/loader/loader.go
+++ b/pkg/test/loader/loader.go
@@ -244,7 +244,7 @@ func (r *TestResource) UnmarshalYAML(node *yaml.Node) error {
 // marshal the content.
 // TODO: this method should be implemented with a pointer receiver but unfortunately, the yaml.v3 library is only able
 // to call it if it is implemented with a value receiver. Uniform the receivers once the library is replaced.
-func (r TestResource) MarshalYAML() (interface{}, error) {
+func (r TestResource) MarshalYAML() (any, error) {
 	switch resourceType := r.Type; resourceType {
 	case TestResourceTypeClientServer:
 		return struct {
@@ -271,7 +271,7 @@ func (r TestResource) MarshalYAML() (interface{}, error) {
 // provide an addition MarshalYAML method for TestResourceFDSpec, as it will not be called by the library if the Spec
 // field specify "inline" (as it should be in our case). Take care of replace this with a more elegant solution once
 // yaml.v3 is replaced.
-func (r *TestResource) marshalFD() (interface{}, error) {
+func (r *TestResource) marshalFD() (any, error) {
 	spec := r.Spec.(*TestResourceFDSpec)
 	subSpec := spec.Spec
 	switch subtype := spec.Subtype; subtype {
@@ -592,11 +592,11 @@ func (s *TestStep) UnmarshalYAML(node *yaml.Node) error {
 // marshal the content.
 // TODO: this method should be implemented with a pointer receiver but unfortunately, the yaml.v3 library is only able
 // to call it if it is implemented with a value receiver. Uniform the receivers once the library is replaced.
-func (s TestStep) MarshalYAML() (interface{}, error) {
+func (s TestStep) MarshalYAML() (any, error) {
 	switch stepType := s.Type; stepType {
 	case TestStepTypeSyscall:
 		spec := s.Spec.(*TestStepSyscallSpec)
-		args := make(map[string]interface{}, len(spec.Args)+len(s.FieldBindings))
+		args := make(map[string]any, len(spec.Args)+len(s.FieldBindings))
 		for arg, argValue := range spec.Args {
 			args[arg] = argValue
 		}
@@ -640,8 +640,8 @@ func (t *TestStepType) UnmarshalYAML(node *yaml.Node) error {
 
 // TestStepSyscallSpec describes a system call test step.
 type TestStepSyscallSpec struct {
-	Syscall SyscallName            `yaml:"syscall" validate:"-"`
-	Args    map[string]interface{} `yaml:"args" validate:"required"`
+	Syscall SyscallName    `yaml:"syscall" validate:"-"`
+	Args    map[string]any `yaml:"args" validate:"required"`
 }
 
 // TestStepFieldBinding contains the information to perform the binding of a field belonging to a source step.
@@ -653,7 +653,7 @@ type TestStepFieldBinding struct {
 
 var fieldBindingRegex = regexp.MustCompile(`^\${(.+?)\.(.+)}$`)
 
-func getFieldBindings(containingArgName string, args map[string]interface{}) []*TestStepFieldBinding {
+func getFieldBindings(containingArgName string, args map[string]any) []*TestStepFieldBinding {
 	// The prefix of each contained argument is composed by the containing argument name.
 	var argsPrefix string
 	if containingArgName != "" {
@@ -678,7 +678,7 @@ func getFieldBindings(containingArgName string, args map[string]interface{}) []*
 
 			// If an argument value is a field binding, remove it from arguments.
 			delete(args, arg)
-		case map[string]interface{}:
+		case map[string]any:
 			bindings = append(bindings, getFieldBindings(arg, argValue)...)
 		}
 	}

--- a/pkg/test/step/syscall/base/base.go
+++ b/pkg/test/step/syscall/base/base.go
@@ -60,7 +60,7 @@ var _ syscall.Syscall = (*baseSyscall)(nil)
 var errOpenModeMustBePositive = fmt.Errorf("open mode must be a positive integer")
 
 // New creates a new generic system call test step.
-func New(stepName string, rawArgs map[string]interface{}, fieldBindings []*step.FieldBinding, argsContainer,
+func New(stepName string, rawArgs map[string]any, fieldBindings []*step.FieldBinding, argsContainer,
 	bindOnlyArgsContainer, retValueContainer reflect.Value, defaultedArgs []string,
 	runFunc, cleanupFunc func(ctx context.Context) error) (syscall.Syscall, error) {
 	if err := checkContainersInvariants(argsContainer, bindOnlyArgsContainer, retValueContainer); err != nil {
@@ -123,7 +123,7 @@ func checkContainersInvariants(argsContainer, bindOnlyArgsContainer, retValueCon
 
 // setArgFieldValues sets the argument fields in argFieldContainer to the corresponding values in rawArgs. It returns
 // the list of set arguments field paths.
-func setArgFieldValues(argFieldContainer reflect.Value, rawArgs map[string]interface{}) ([]string, error) {
+func setArgFieldValues(argFieldContainer reflect.Value, rawArgs map[string]any) ([]string, error) {
 	fmt.Printf("setArgFieldValues rawArgs: %+v\n", rawArgs)
 	var boundArgs []string
 	for rawArg, rawArgValue := range rawArgs {
@@ -146,7 +146,7 @@ func setArgFieldValues(argFieldContainer reflect.Value, rawArgs map[string]inter
 // depending on the field type.
 //
 //nolint:gocyclo // Disable cyclomatic complexity check.
-func setArgFieldValue(argField *field.Field, value interface{}) ([]string, error) {
+func setArgFieldValue(argField *field.Field, value any) ([]string, error) {
 	boundArgs := []string{argField.Path}
 	argFieldValue := argField.Value
 	switch argFieldType := argField.Type; argFieldType {
@@ -280,7 +280,7 @@ func setArgFieldValue(argField *field.Field, value interface{}) ([]string, error
 	return boundArgs, nil
 }
 
-func setSubArgFieldValues(argField *field.Field, value interface{}) ([]string, error) {
+func setSubArgFieldValues(argField *field.Field, value any) ([]string, error) {
 	rawArgs, err := parseMap(value)
 	if err != nil {
 		return nil, fmt.Errorf("cannot parse argument field: %w", err)

--- a/pkg/test/step/syscall/connect/connect.go
+++ b/pkg/test/step/syscall/connect/connect.go
@@ -38,8 +38,7 @@ type connectSyscall struct {
 }
 
 // New creates a new connect system call test step.
-func New(name string, rawArgs map[string]string,
-	fieldBindings []*step.FieldBinding) (syscall.Syscall, error) {
+func New(name string, rawArgs map[string]interface{}, fieldBindings []*step.FieldBinding) (syscall.Syscall, error) {
 	c := &connectSyscall{}
 	argsContainer := reflect.ValueOf(&c.args).Elem()
 	bindOnlyArgsContainer := reflect.ValueOf(&c.bindOnlyArgs).Elem()

--- a/pkg/test/step/syscall/connect/connect.go
+++ b/pkg/test/step/syscall/connect/connect.go
@@ -38,7 +38,7 @@ type connectSyscall struct {
 }
 
 // New creates a new connect system call test step.
-func New(name string, rawArgs map[string]interface{}, fieldBindings []*step.FieldBinding) (syscall.Syscall, error) {
+func New(name string, rawArgs map[string]any, fieldBindings []*step.FieldBinding) (syscall.Syscall, error) {
 	c := &connectSyscall{}
 	argsContainer := reflect.ValueOf(&c.args).Elem()
 	bindOnlyArgsContainer := reflect.ValueOf(&c.bindOnlyArgs).Elem()

--- a/pkg/test/step/syscall/dup/dup.go
+++ b/pkg/test/step/syscall/dup/dup.go
@@ -37,7 +37,7 @@ type dupSyscall struct {
 }
 
 // New creates a new dup system call test step.
-func New(name string, rawArgs map[string]interface{}, fieldBindings []*step.FieldBinding) (syscall.Syscall, error) {
+func New(name string, rawArgs map[string]any, fieldBindings []*step.FieldBinding) (syscall.Syscall, error) {
 	d := &dupSyscall{}
 	argsContainer := reflect.ValueOf(&d.args).Elem()
 	bindOnlyArgsContainer := reflect.ValueOf(&d.bindOnlyArgs).Elem()

--- a/pkg/test/step/syscall/dup/dup.go
+++ b/pkg/test/step/syscall/dup/dup.go
@@ -37,13 +37,13 @@ type dupSyscall struct {
 }
 
 // New creates a new dup system call test step.
-func New(name string, rawArgs map[string]string,
-	fieldBindings []*step.FieldBinding) (syscall.Syscall, error) {
+func New(name string, rawArgs map[string]interface{}, fieldBindings []*step.FieldBinding) (syscall.Syscall, error) {
 	d := &dupSyscall{}
 	argsContainer := reflect.ValueOf(&d.args).Elem()
 	bindOnlyArgsContainer := reflect.ValueOf(&d.bindOnlyArgs).Elem()
 	retValContainer := reflect.ValueOf(d).Elem()
-	return base.New(name, rawArgs, fieldBindings, argsContainer, bindOnlyArgsContainer, retValContainer, nil, d.run, nil)
+	return base.New(name, rawArgs, fieldBindings, argsContainer, bindOnlyArgsContainer, retValContainer, nil, d.run,
+		nil)
 }
 
 func (d *dupSyscall) run(_ context.Context) error {

--- a/pkg/test/step/syscall/dup2/dup2.go
+++ b/pkg/test/step/syscall/dup2/dup2.go
@@ -42,7 +42,7 @@ type dup2Syscall struct {
 }
 
 // New creates a new dup2 system call test step.
-func New(name string, rawArgs map[string]interface{}, fieldBindings []*step.FieldBinding) (syscall.Syscall, error) {
+func New(name string, rawArgs map[string]any, fieldBindings []*step.FieldBinding) (syscall.Syscall, error) {
 	d := &dup2Syscall{savedFD: -1}
 	argsContainer := reflect.ValueOf(&d.args).Elem()
 	bindOnlyArgsContainer := reflect.ValueOf(&d.bindOnlyArgs).Elem()

--- a/pkg/test/step/syscall/dup2/dup2.go
+++ b/pkg/test/step/syscall/dup2/dup2.go
@@ -42,7 +42,7 @@ type dup2Syscall struct {
 }
 
 // New creates a new dup2 system call test step.
-func New(name string, rawArgs map[string]string, fieldBindings []*step.FieldBinding) (syscall.Syscall, error) {
+func New(name string, rawArgs map[string]interface{}, fieldBindings []*step.FieldBinding) (syscall.Syscall, error) {
 	d := &dup2Syscall{savedFD: -1}
 	argsContainer := reflect.ValueOf(&d.args).Elem()
 	bindOnlyArgsContainer := reflect.ValueOf(&d.bindOnlyArgs).Elem()

--- a/pkg/test/step/syscall/dup2/dup2_arm64.go
+++ b/pkg/test/step/syscall/dup2/dup2_arm64.go
@@ -22,6 +22,6 @@ import (
 	"github.com/falcosecurity/event-generator/pkg/test/step/syscall"
 )
 
-func New(_ string, _ map[string]string, _ []*step.FieldBinding) (syscall.Syscall, error) {
+func New(_ string, _ map[string]interface{}, _ []*step.FieldBinding) (syscall.Syscall, error) {
 	return nil, fmt.Errorf("not supported by the architecture")
 }

--- a/pkg/test/step/syscall/dup2/dup2_arm64.go
+++ b/pkg/test/step/syscall/dup2/dup2_arm64.go
@@ -22,6 +22,6 @@ import (
 	"github.com/falcosecurity/event-generator/pkg/test/step/syscall"
 )
 
-func New(_ string, _ map[string]interface{}, _ []*step.FieldBinding) (syscall.Syscall, error) {
+func New(_ string, _ map[string]any, _ []*step.FieldBinding) (syscall.Syscall, error) {
 	return nil, fmt.Errorf("not supported by the architecture")
 }

--- a/pkg/test/step/syscall/dup3/dup3.go
+++ b/pkg/test/step/syscall/dup3/dup3.go
@@ -41,8 +41,7 @@ type dup3Syscall struct {
 }
 
 // New creates a new dup3 system call test step.
-func New(name string, rawArgs map[string]string,
-	fieldBindings []*step.FieldBinding) (syscall.Syscall, error) {
+func New(name string, rawArgs map[string]interface{}, fieldBindings []*step.FieldBinding) (syscall.Syscall, error) {
 	d := &dup3Syscall{savedFD: -1}
 	// d.args.Flags defaulted to 0
 	argsContainer := reflect.ValueOf(&d.args).Elem()

--- a/pkg/test/step/syscall/dup3/dup3.go
+++ b/pkg/test/step/syscall/dup3/dup3.go
@@ -41,7 +41,7 @@ type dup3Syscall struct {
 }
 
 // New creates a new dup3 system call test step.
-func New(name string, rawArgs map[string]interface{}, fieldBindings []*step.FieldBinding) (syscall.Syscall, error) {
+func New(name string, rawArgs map[string]any, fieldBindings []*step.FieldBinding) (syscall.Syscall, error) {
 	d := &dup3Syscall{savedFD: -1}
 	// d.args.Flags defaulted to 0
 	argsContainer := reflect.ValueOf(&d.args).Elem()

--- a/pkg/test/step/syscall/dup3/dup3.go
+++ b/pkg/test/step/syscall/dup3/dup3.go
@@ -43,7 +43,7 @@ type dup3Syscall struct {
 // New creates a new dup3 system call test step.
 func New(name string, rawArgs map[string]string,
 	fieldBindings []*step.FieldBinding) (syscall.Syscall, error) {
-	d := &dup3Syscall{}
+	d := &dup3Syscall{savedFD: -1}
 	// d.args.Flags defaulted to 0
 	argsContainer := reflect.ValueOf(&d.args).Elem()
 	bindOnlyArgsContainer := reflect.ValueOf(&d.bindOnlyArgs).Elem()

--- a/pkg/test/step/syscall/finitmodule/finitmodule.go
+++ b/pkg/test/step/syscall/finitmodule/finitmodule.go
@@ -40,8 +40,7 @@ type finitModuleSyscall struct {
 }
 
 // New creates a new finit_module system call test step.
-func New(name string, rawArgs map[string]string,
-	fieldBindings []*step.FieldBinding) (syscall.Syscall, error) {
+func New(name string, rawArgs map[string]interface{}, fieldBindings []*step.FieldBinding) (syscall.Syscall, error) {
 	f := &finitModuleSyscall{}
 	// f.args.ParamValues defaulted to ""
 	// f.args.Flags defaulted to 0

--- a/pkg/test/step/syscall/finitmodule/finitmodule.go
+++ b/pkg/test/step/syscall/finitmodule/finitmodule.go
@@ -40,7 +40,7 @@ type finitModuleSyscall struct {
 }
 
 // New creates a new finit_module system call test step.
-func New(name string, rawArgs map[string]interface{}, fieldBindings []*step.FieldBinding) (syscall.Syscall, error) {
+func New(name string, rawArgs map[string]any, fieldBindings []*step.FieldBinding) (syscall.Syscall, error) {
 	f := &finitModuleSyscall{}
 	// f.args.ParamValues defaulted to ""
 	// f.args.Flags defaulted to 0

--- a/pkg/test/step/syscall/initmodule/initmodule.go
+++ b/pkg/test/step/syscall/initmodule/initmodule.go
@@ -38,7 +38,7 @@ type initModuleSyscall struct {
 }
 
 // New creates a new init_module system call test step.
-func New(name string, rawArgs map[string]interface{}, fieldBindings []*step.FieldBinding) (syscall.Syscall, error) {
+func New(name string, rawArgs map[string]any, fieldBindings []*step.FieldBinding) (syscall.Syscall, error) {
 	i := &initModuleSyscall{}
 	// i.args.ParamValues defaulted to ""
 	argsContainer := reflect.ValueOf(&i.args).Elem()

--- a/pkg/test/step/syscall/initmodule/initmodule.go
+++ b/pkg/test/step/syscall/initmodule/initmodule.go
@@ -38,8 +38,7 @@ type initModuleSyscall struct {
 }
 
 // New creates a new init_module system call test step.
-func New(name string, rawArgs map[string]string,
-	fieldBindings []*step.FieldBinding) (syscall.Syscall, error) {
+func New(name string, rawArgs map[string]interface{}, fieldBindings []*step.FieldBinding) (syscall.Syscall, error) {
 	i := &initModuleSyscall{}
 	// i.args.ParamValues defaulted to ""
 	argsContainer := reflect.ValueOf(&i.args).Elem()

--- a/pkg/test/step/syscall/kill/kill.go
+++ b/pkg/test/step/syscall/kill/kill.go
@@ -39,8 +39,7 @@ type killSyscall struct {
 }
 
 // New creates a new kill system call test step.
-func New(name string, rawArgs map[string]string,
-	fieldBindings []*step.FieldBinding) (syscall.Syscall, error) {
+func New(name string, rawArgs map[string]interface{}, fieldBindings []*step.FieldBinding) (syscall.Syscall, error) {
 	k := &killSyscall{}
 	argsContainer := reflect.ValueOf(&k.args).Elem()
 	bindOnlyArgsContainer := reflect.ValueOf(&k.bindOnlyArgs).Elem()

--- a/pkg/test/step/syscall/kill/kill.go
+++ b/pkg/test/step/syscall/kill/kill.go
@@ -39,7 +39,7 @@ type killSyscall struct {
 }
 
 // New creates a new kill system call test step.
-func New(name string, rawArgs map[string]interface{}, fieldBindings []*step.FieldBinding) (syscall.Syscall, error) {
+func New(name string, rawArgs map[string]any, fieldBindings []*step.FieldBinding) (syscall.Syscall, error) {
 	k := &killSyscall{}
 	argsContainer := reflect.ValueOf(&k.args).Elem()
 	bindOnlyArgsContainer := reflect.ValueOf(&k.bindOnlyArgs).Elem()

--- a/pkg/test/step/syscall/link/link.go
+++ b/pkg/test/step/syscall/link/link.go
@@ -43,7 +43,7 @@ type linkSyscall struct {
 }
 
 // New creates a new link system call test step.
-func New(name string, rawArgs map[string]string, fieldBindings []*step.FieldBinding) (syscall.Syscall, error) {
+func New(name string, rawArgs map[string]interface{}, fieldBindings []*step.FieldBinding) (syscall.Syscall, error) {
 	l := &linkSyscall{}
 	argsContainer := reflect.ValueOf(&l.args).Elem()
 	bindOnlyArgsContainer := reflect.ValueOf(&l.bindOnlyArgs).Elem()

--- a/pkg/test/step/syscall/link/link.go
+++ b/pkg/test/step/syscall/link/link.go
@@ -43,7 +43,7 @@ type linkSyscall struct {
 }
 
 // New creates a new link system call test step.
-func New(name string, rawArgs map[string]interface{}, fieldBindings []*step.FieldBinding) (syscall.Syscall, error) {
+func New(name string, rawArgs map[string]any, fieldBindings []*step.FieldBinding) (syscall.Syscall, error) {
 	l := &linkSyscall{}
 	argsContainer := reflect.ValueOf(&l.args).Elem()
 	bindOnlyArgsContainer := reflect.ValueOf(&l.bindOnlyArgs).Elem()

--- a/pkg/test/step/syscall/link/link_arm64.go
+++ b/pkg/test/step/syscall/link/link_arm64.go
@@ -22,6 +22,6 @@ import (
 	"github.com/falcosecurity/event-generator/pkg/test/step/syscall"
 )
 
-func New(_ string, _ map[string]string, _ []*step.FieldBinding) (syscall.Syscall, error) {
+func New(_ string, _ map[string]interface{}, _ []*step.FieldBinding) (syscall.Syscall, error) {
 	return nil, fmt.Errorf("not supported by the architecture")
 }

--- a/pkg/test/step/syscall/link/link_arm64.go
+++ b/pkg/test/step/syscall/link/link_arm64.go
@@ -22,6 +22,6 @@ import (
 	"github.com/falcosecurity/event-generator/pkg/test/step/syscall"
 )
 
-func New(_ string, _ map[string]interface{}, _ []*step.FieldBinding) (syscall.Syscall, error) {
+func New(_ string, _ map[string]any, _ []*step.FieldBinding) (syscall.Syscall, error) {
 	return nil, fmt.Errorf("not supported by the architecture")
 }

--- a/pkg/test/step/syscall/linkat/linkat.go
+++ b/pkg/test/step/syscall/linkat/linkat.go
@@ -45,7 +45,7 @@ type linkAtSyscall struct {
 }
 
 // New creates a new linkat system call test step.
-func New(name string, rawArgs map[string]interface{}, fieldBindings []*step.FieldBinding) (syscall.Syscall, error) {
+func New(name string, rawArgs map[string]any, fieldBindings []*step.FieldBinding) (syscall.Syscall, error) {
 	l := &linkAtSyscall{}
 	l.bindOnlyArgs.OldDirFD = unix.AT_FDCWD
 	l.bindOnlyArgs.NewDirFD = unix.AT_FDCWD

--- a/pkg/test/step/syscall/linkat/linkat.go
+++ b/pkg/test/step/syscall/linkat/linkat.go
@@ -45,7 +45,7 @@ type linkAtSyscall struct {
 }
 
 // New creates a new linkat system call test step.
-func New(name string, rawArgs map[string]string, fieldBindings []*step.FieldBinding) (syscall.Syscall, error) {
+func New(name string, rawArgs map[string]interface{}, fieldBindings []*step.FieldBinding) (syscall.Syscall, error) {
 	l := &linkAtSyscall{}
 	l.bindOnlyArgs.OldDirFD = unix.AT_FDCWD
 	l.bindOnlyArgs.NewDirFD = unix.AT_FDCWD

--- a/pkg/test/step/syscall/open/open.go
+++ b/pkg/test/step/syscall/open/open.go
@@ -42,7 +42,7 @@ type openSyscall struct {
 }
 
 // New creates a new open system call test step.
-func New(name string, rawArgs map[string]interface{}, fieldBindings []*step.FieldBinding) (syscall.Syscall, error) {
+func New(name string, rawArgs map[string]any, fieldBindings []*step.FieldBinding) (syscall.Syscall, error) {
 	o := &openSyscall{}
 	// o.args.Mode defaulted to 0
 	argsContainer := reflect.ValueOf(&o.args).Elem()

--- a/pkg/test/step/syscall/open/open.go
+++ b/pkg/test/step/syscall/open/open.go
@@ -42,9 +42,9 @@ type openSyscall struct {
 }
 
 // New creates a new open system call test step.
-func New(name string, rawArgs map[string]string, fieldBindings []*step.FieldBinding) (syscall.Syscall, error) {
+func New(name string, rawArgs map[string]interface{}, fieldBindings []*step.FieldBinding) (syscall.Syscall, error) {
 	o := &openSyscall{}
-	// mode defaulted to 0
+	// o.args.Mode defaulted to 0
 	argsContainer := reflect.ValueOf(&o.args).Elem()
 	bindOnlyArgsContainer := reflect.ValueOf(&o.bindOnlyArgs).Elem()
 	retValContainer := reflect.ValueOf(o).Elem()

--- a/pkg/test/step/syscall/open/open_arm64.go
+++ b/pkg/test/step/syscall/open/open_arm64.go
@@ -22,6 +22,6 @@ import (
 	"github.com/falcosecurity/event-generator/pkg/test/step/syscall"
 )
 
-func New(_ string, _ map[string]string, _ []*step.FieldBinding) (syscall.Syscall, error) {
+func New(_ string, _ map[string]interface{}, _ []*step.FieldBinding) (syscall.Syscall, error) {
 	return nil, fmt.Errorf("not supported by the architecture")
 }

--- a/pkg/test/step/syscall/open/open_arm64.go
+++ b/pkg/test/step/syscall/open/open_arm64.go
@@ -22,6 +22,6 @@ import (
 	"github.com/falcosecurity/event-generator/pkg/test/step/syscall"
 )
 
-func New(_ string, _ map[string]interface{}, _ []*step.FieldBinding) (syscall.Syscall, error) {
+func New(_ string, _ map[string]any, _ []*step.FieldBinding) (syscall.Syscall, error) {
 	return nil, fmt.Errorf("not supported by the architecture")
 }

--- a/pkg/test/step/syscall/openat/openat.go
+++ b/pkg/test/step/syscall/openat/openat.go
@@ -42,7 +42,7 @@ type openAtSyscall struct {
 }
 
 // New creates a new openat system call test step.
-func New(name string, rawArgs map[string]interface{}, fieldBindings []*step.FieldBinding) (syscall.Syscall, error) {
+func New(name string, rawArgs map[string]any, fieldBindings []*step.FieldBinding) (syscall.Syscall, error) {
 	o := &openAtSyscall{}
 	o.bindOnlyArgs.DirFD = unix.AT_FDCWD
 	// o.args.Mode defaulted to 0

--- a/pkg/test/step/syscall/openat/openat.go
+++ b/pkg/test/step/syscall/openat/openat.go
@@ -42,8 +42,7 @@ type openAtSyscall struct {
 }
 
 // New creates a new openat system call test step.
-func New(name string, rawArgs map[string]string,
-	fieldBindings []*step.FieldBinding) (syscall.Syscall, error) {
+func New(name string, rawArgs map[string]interface{}, fieldBindings []*step.FieldBinding) (syscall.Syscall, error) {
 	o := &openAtSyscall{}
 	o.bindOnlyArgs.DirFD = unix.AT_FDCWD
 	// o.args.Mode defaulted to 0

--- a/pkg/test/step/syscall/openat2/openat2.go
+++ b/pkg/test/step/syscall/openat2/openat2.go
@@ -46,7 +46,7 @@ type openAt2Syscall struct {
 }
 
 // New creates a new openat2 system call test step.
-func New(name string, rawArgs map[string]interface{}, fieldBindings []*step.FieldBinding) (syscall.Syscall, error) {
+func New(name string, rawArgs map[string]any, fieldBindings []*step.FieldBinding) (syscall.Syscall, error) {
 	o := &openAt2Syscall{}
 	o.bindOnlyArgs.DirFD = unix.AT_FDCWD
 	// o.args.How field defaulted to empty struct.

--- a/pkg/test/step/syscall/openat2/openat2.go
+++ b/pkg/test/step/syscall/openat2/openat2.go
@@ -17,6 +17,7 @@ package openat2
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"unsafe"
 
@@ -30,8 +31,12 @@ import (
 type openAt2Syscall struct {
 	// args represents arguments that can be provided by value or by binding.
 	args struct {
-		Pathname []byte       `field_type:"file_path"`
-		How      unix.OpenHow `field_type:"open_how"`
+		Pathname []byte `field_type:"file_path"`
+		How      struct {
+			Flags   uint64 `field_type:"open_how_flags"`
+			Mode    uint64 `field_type:"open_how_mode"`
+			Resolve uint64 `field_type:"open_how_resolve"`
+		} `field_type:"open_how"`
 	}
 	// bindOnlyArgs represents arguments that can only be provided by binding.
 	bindOnlyArgs struct {
@@ -41,20 +46,20 @@ type openAt2Syscall struct {
 }
 
 // New creates a new openat2 system call test step.
-func New(name string, rawArgs map[string]string,
-	fieldBindings []*step.FieldBinding) (syscall.Syscall, error) {
+func New(name string, rawArgs map[string]interface{}, fieldBindings []*step.FieldBinding) (syscall.Syscall, error) {
 	o := &openAt2Syscall{}
 	o.bindOnlyArgs.DirFD = unix.AT_FDCWD
 	// o.args.How field defaulted to empty struct.
 	argsContainer := reflect.ValueOf(&o.args).Elem()
 	bindOnlyArgsContainer := reflect.ValueOf(&o.bindOnlyArgs).Elem()
 	retValContainer := reflect.ValueOf(o).Elem()
-	defaultedArgs := []string{"dirfd", "how"}
+	defaultedArgs := []string{"dirfd", "how", "how.flags", "how.mode", "how.resolve"}
 	return base.New(name, rawArgs, fieldBindings, argsContainer, bindOnlyArgsContainer, retValContainer, defaultedArgs,
 		o.run, nil)
 }
 
 func (o *openAt2Syscall) run(_ context.Context) error {
+	fmt.Printf("%+v\n", *o)
 	//nolint:gosec // System call invocation requires access to the raw pointer.
 	pathnamePtr := unsafe.Pointer(&o.args.Pathname[0])
 	//nolint:gosec // System call invocation requires access to the raw pointer.

--- a/pkg/test/step/syscall/openat2/openat2.go
+++ b/pkg/test/step/syscall/openat2/openat2.go
@@ -45,11 +45,11 @@ func New(name string, rawArgs map[string]string,
 	fieldBindings []*step.FieldBinding) (syscall.Syscall, error) {
 	o := &openAt2Syscall{}
 	o.bindOnlyArgs.DirFD = unix.AT_FDCWD
-	// o.args.How fields defaulted to 0
+	// o.args.How field defaulted to empty struct.
 	argsContainer := reflect.ValueOf(&o.args).Elem()
 	bindOnlyArgsContainer := reflect.ValueOf(&o.bindOnlyArgs).Elem()
 	retValContainer := reflect.ValueOf(o).Elem()
-	defaultedArgs := []string{"dirfd", "mode"}
+	defaultedArgs := []string{"dirfd", "how"}
 	return base.New(name, rawArgs, fieldBindings, argsContainer, bindOnlyArgsContainer, retValContainer, defaultedArgs,
 		o.run, nil)
 }

--- a/pkg/test/step/syscall/read/read.go
+++ b/pkg/test/step/syscall/read/read.go
@@ -39,7 +39,7 @@ type readSyscall struct {
 }
 
 // New creates a new read system call test step.
-func New(name string, rawArgs map[string]interface{}, fieldBindings []*step.FieldBinding) (syscall.Syscall, error) {
+func New(name string, rawArgs map[string]any, fieldBindings []*step.FieldBinding) (syscall.Syscall, error) {
 	r := &readSyscall{}
 	argsContainer := reflect.ValueOf(&r.args).Elem()
 	bindOnlyArgsContainer := reflect.ValueOf(&r.bindOnlyArgs).Elem()

--- a/pkg/test/step/syscall/read/read.go
+++ b/pkg/test/step/syscall/read/read.go
@@ -39,8 +39,7 @@ type readSyscall struct {
 }
 
 // New creates a new read system call test step.
-func New(name string, rawArgs map[string]string,
-	fieldBindings []*step.FieldBinding) (syscall.Syscall, error) {
+func New(name string, rawArgs map[string]interface{}, fieldBindings []*step.FieldBinding) (syscall.Syscall, error) {
 	r := &readSyscall{}
 	argsContainer := reflect.ValueOf(&r.args).Elem()
 	bindOnlyArgsContainer := reflect.ValueOf(&r.bindOnlyArgs).Elem()

--- a/pkg/test/step/syscall/sendto/sendto.go
+++ b/pkg/test/step/syscall/sendto/sendto.go
@@ -45,7 +45,7 @@ type sendToSyscall struct {
 }
 
 // New creates a new sendto system call test step.
-func New(name string, rawArgs map[string]interface{}, fieldBindings []*step.FieldBinding) (syscall.Syscall, error) {
+func New(name string, rawArgs map[string]any, fieldBindings []*step.FieldBinding) (syscall.Syscall, error) {
 	s := &sendToSyscall{}
 	// s.args.Len defaults to the buffer length at run time, if unbound.
 	argsContainer := reflect.ValueOf(&s.args).Elem()

--- a/pkg/test/step/syscall/sendto/sendto.go
+++ b/pkg/test/step/syscall/sendto/sendto.go
@@ -45,8 +45,7 @@ type sendToSyscall struct {
 }
 
 // New creates a new sendto system call test step.
-func New(name string, rawArgs map[string]string,
-	fieldBindings []*step.FieldBinding) (syscall.Syscall, error) {
+func New(name string, rawArgs map[string]interface{}, fieldBindings []*step.FieldBinding) (syscall.Syscall, error) {
 	s := &sendToSyscall{}
 	// s.args.Len defaults to the buffer length at run time, if unbound.
 	argsContainer := reflect.ValueOf(&s.args).Elem()

--- a/pkg/test/step/syscall/socket/socket.go
+++ b/pkg/test/step/syscall/socket/socket.go
@@ -39,7 +39,7 @@ type socketSyscall struct {
 }
 
 // New creates a new socket system call test step.
-func New(name string, rawArgs map[string]interface{}, fieldBindings []*step.FieldBinding) (syscall.Syscall, error) {
+func New(name string, rawArgs map[string]any, fieldBindings []*step.FieldBinding) (syscall.Syscall, error) {
 	s := &socketSyscall{}
 	argsContainer := reflect.ValueOf(&s.args).Elem()
 	bindOnlyArgsContainer := reflect.ValueOf(&s.bindOnlyArgs).Elem()

--- a/pkg/test/step/syscall/socket/socket.go
+++ b/pkg/test/step/syscall/socket/socket.go
@@ -39,8 +39,7 @@ type socketSyscall struct {
 }
 
 // New creates a new socket system call test step.
-func New(name string, rawArgs map[string]string,
-	fieldBindings []*step.FieldBinding) (syscall.Syscall, error) {
+func New(name string, rawArgs map[string]interface{}, fieldBindings []*step.FieldBinding) (syscall.Syscall, error) {
 	s := &socketSyscall{}
 	argsContainer := reflect.ValueOf(&s.args).Elem()
 	bindOnlyArgsContainer := reflect.ValueOf(&s.bindOnlyArgs).Elem()

--- a/pkg/test/step/syscall/symlink/symlink.go
+++ b/pkg/test/step/syscall/symlink/symlink.go
@@ -43,7 +43,7 @@ type symlinkSyscall struct {
 }
 
 // New creates a new symlink system call test step.
-func New(name string, rawArgs map[string]string, fieldBindings []*step.FieldBinding) (syscall.Syscall, error) {
+func New(name string, rawArgs map[string]interface{}, fieldBindings []*step.FieldBinding) (syscall.Syscall, error) {
 	s := &symlinkSyscall{}
 	argsContainer := reflect.ValueOf(&s.args).Elem()
 	bindOnlyArgsContainer := reflect.ValueOf(&s.bindOnlyArgs).Elem()

--- a/pkg/test/step/syscall/symlink/symlink.go
+++ b/pkg/test/step/syscall/symlink/symlink.go
@@ -43,7 +43,7 @@ type symlinkSyscall struct {
 }
 
 // New creates a new symlink system call test step.
-func New(name string, rawArgs map[string]interface{}, fieldBindings []*step.FieldBinding) (syscall.Syscall, error) {
+func New(name string, rawArgs map[string]any, fieldBindings []*step.FieldBinding) (syscall.Syscall, error) {
 	s := &symlinkSyscall{}
 	argsContainer := reflect.ValueOf(&s.args).Elem()
 	bindOnlyArgsContainer := reflect.ValueOf(&s.bindOnlyArgs).Elem()

--- a/pkg/test/step/syscall/symlink/symlink_arm64.go
+++ b/pkg/test/step/syscall/symlink/symlink_arm64.go
@@ -22,6 +22,6 @@ import (
 	"github.com/falcosecurity/event-generator/pkg/test/step/syscall"
 )
 
-func New(_ string, _ map[string]string, _ []*step.FieldBinding) (syscall.Syscall, error) {
+func New(_ string, _ map[string]interface{}, _ []*step.FieldBinding) (syscall.Syscall, error) {
 	return nil, fmt.Errorf("not supported by the architecture")
 }

--- a/pkg/test/step/syscall/symlink/symlink_arm64.go
+++ b/pkg/test/step/syscall/symlink/symlink_arm64.go
@@ -22,6 +22,6 @@ import (
 	"github.com/falcosecurity/event-generator/pkg/test/step/syscall"
 )
 
-func New(_ string, _ map[string]interface{}, _ []*step.FieldBinding) (syscall.Syscall, error) {
+func New(_ string, _ map[string]any, _ []*step.FieldBinding) (syscall.Syscall, error) {
 	return nil, fmt.Errorf("not supported by the architecture")
 }

--- a/pkg/test/step/syscall/symlinkat/symlinkat.go
+++ b/pkg/test/step/syscall/symlinkat/symlinkat.go
@@ -43,8 +43,7 @@ type symlinkAtSyscall struct {
 }
 
 // New creates a new symlinkat system call test step.
-func New(name string, rawArgs map[string]string,
-	fieldBindings []*step.FieldBinding) (syscall.Syscall, error) {
+func New(name string, rawArgs map[string]interface{}, fieldBindings []*step.FieldBinding) (syscall.Syscall, error) {
 	s := &symlinkAtSyscall{}
 	s.bindOnlyArgs.NewDirFD = unix.AT_FDCWD
 	argsContainer := reflect.ValueOf(&s.args).Elem()

--- a/pkg/test/step/syscall/symlinkat/symlinkat.go
+++ b/pkg/test/step/syscall/symlinkat/symlinkat.go
@@ -82,7 +82,7 @@ func (s *symlinkAtSyscall) cleanup(_ context.Context) error {
 		s.savedLinkPath = nil
 	}()
 
-	dirFD := unix.AT_FDCWD
+	dirFD := s.bindOnlyArgs.NewDirFD
 	//nolint:gosec // System call invocation requires access to the raw pointer.
 	savedLinkPathPtr := unsafe.Pointer(&s.savedLinkPath[0])
 	flags := 0

--- a/pkg/test/step/syscall/symlinkat/symlinkat.go
+++ b/pkg/test/step/syscall/symlinkat/symlinkat.go
@@ -43,7 +43,7 @@ type symlinkAtSyscall struct {
 }
 
 // New creates a new symlinkat system call test step.
-func New(name string, rawArgs map[string]interface{}, fieldBindings []*step.FieldBinding) (syscall.Syscall, error) {
+func New(name string, rawArgs map[string]any, fieldBindings []*step.FieldBinding) (syscall.Syscall, error) {
 	s := &symlinkAtSyscall{}
 	s.bindOnlyArgs.NewDirFD = unix.AT_FDCWD
 	argsContainer := reflect.ValueOf(&s.args).Elem()

--- a/pkg/test/step/syscall/syscall.go
+++ b/pkg/test/step/syscall/syscall.go
@@ -74,6 +74,6 @@ const (
 
 // Description contains information to build a new Syscall test step.
 type Description struct {
-	RawArgs       map[string]interface{}
+	RawArgs       map[string]any
 	FieldBindings []*step.FieldBinding
 }

--- a/pkg/test/step/syscall/syscall.go
+++ b/pkg/test/step/syscall/syscall.go
@@ -74,6 +74,6 @@ const (
 
 // Description contains information to build a new Syscall test step.
 type Description struct {
-	RawArgs       map[string]string
+	RawArgs       map[string]interface{}
 	FieldBindings []*step.FieldBinding
 }

--- a/pkg/test/step/syscall/write/write.go
+++ b/pkg/test/step/syscall/write/write.go
@@ -39,8 +39,7 @@ type writeSyscall struct {
 }
 
 // New creates a new write system call test step.
-func New(name string, rawArgs map[string]string,
-	fieldBindings []*step.FieldBinding) (syscall.Syscall, error) {
+func New(name string, rawArgs map[string]interface{}, fieldBindings []*step.FieldBinding) (syscall.Syscall, error) {
 	w := &writeSyscall{}
 	// w.args.Len defaults to the buffer length at run time, if unbound.
 	argsContainer := reflect.ValueOf(&w.args).Elem()

--- a/pkg/test/step/syscall/write/write.go
+++ b/pkg/test/step/syscall/write/write.go
@@ -39,7 +39,7 @@ type writeSyscall struct {
 }
 
 // New creates a new write system call test step.
-func New(name string, rawArgs map[string]interface{}, fieldBindings []*step.FieldBinding) (syscall.Syscall, error) {
+func New(name string, rawArgs map[string]any, fieldBindings []*step.FieldBinding) (syscall.Syscall, error) {
 	w := &writeSyscall{}
 	// w.args.Len defaults to the buffer length at run time, if unbound.
 	argsContainer := reflect.ValueOf(&w.args).Elem()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note: it's really useful for the changelog!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind documentation

> /kind tests

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area commands

/area pkg

> /area events

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:
This PR fixes the system call arguments are handled, starting from the decoding phase up to the system call step arguments settings. Specifically, arguments are now parsed as `map[string]interface{}` (instead of `map[string]string`): this enables field binding at arbitrary level and decouples architecture inner layers from tests input encoding.

Moreover, this PR replaces `interface{}` with the equivalent but more explicit `any`.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

