### PR TITLE
feat(decl/loader): add support for generating documentation node tree

### DIFF
--- a/pkg/test/loader/schema/describe.go
+++ b/pkg/test/loader/schema/describe.go
@@ -1,0 +1,555 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2024 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package schema
+
+import (
+	"cmp"
+	"fmt"
+	"math/big"
+
+	"github.com/go-viper/mapstructure/v2"
+	"github.com/santhosh-tekuri/jsonschema/v6"
+)
+
+// EnumRequirement specifies an enumerated value in the node tree and the corresponding value to set.
+type EnumRequirement struct {
+	// PathSegments is the list of enum path segments.
+	PathSegments []string
+	// Value is the enum value.
+	Value string
+}
+
+// NodeMetadata contains node metadata.
+type NodeMetadata struct {
+	Type       string
+	IsBindOnly bool
+}
+
+// A Node represents a single schema element.
+type Node struct {
+	// Name is the name of the node.
+	Name string
+	// Descriptions is the list of node's descriptions. A node can have multiple descriptions if it is the result of the
+	// merging of multiple nodes.
+	Descriptions []string
+	// JSONTypes is the node's optional list of JSON types.
+	JSONTypes []string
+	// Required is true if the user is required to provide the current node in order to completely describe the
+	// containing node.
+	Required bool
+	// Minimum is the minimum supported integer value (it can be different from nil only if JSONTypes contains the
+	// integer type).
+	Minimum *float64
+	// MinLength is the minimum string value length (it can be different from nil only if JSONTypes contains the string
+	// type).
+	MinLength *int
+	// MinItems is the minimum number of node items (it can be different from nil only if JSONTypes contains the array
+	// type).
+	MinItems *int
+	// MinProperties is the minimum number of properties the node can contain (it can be different from nil only if
+	// JSONTypes contains the object type).
+	MinProperties *int
+	// Pattern is the regular expression the node is constrained to adhere (it can be different from nil only if
+	// JSONTypes contains the string type).
+	Pattern *string
+	// Default is the node's optional default value.
+	Default *any
+	// Examples is the node's optional list of examples.
+	Examples []any
+	// Enum is the node's optional list of enumerated values that are allowed to be set as node's value. It is only
+	// populated if the node represents an enumerated value.
+	Enum []any
+	// Children is the node's optional list of child nodes (a.k.a node's fields).
+	Children []*Node
+	// PseudoChildren is the node's optional list of pseudo child nodes (a.k.a node's exposed fields).
+	PseudoChildren []*Node
+	// Pseudo is true if the node is "pseudo" node. In the context of a node tree, a pseudo node is a node not present
+	// in the original schema: it is added to augment the schema with additional information, such as node's additional
+	// exposed fields.
+	Pseudo bool
+	// Metadata are the node's metadata.
+	Metadata *NodeMetadata
+}
+
+// mergeMetadataSchema merges the provided metadata schema in the current node.
+func (n *Node) mergeMetadataSchema(metadataSchema *jsonschema.Schema) error {
+	parsedMetadata, err := parseMetadata(metadataSchema)
+	if err != nil {
+		return fmt.Errorf("error parsing metadata: %w", err)
+	}
+
+	n.mergeMetadata(parsedMetadata)
+	return nil
+}
+
+type fieldMetadata struct {
+	Type              string                    `mapstructure:"fieldType"`
+	Description       string                    `mapstructure:"description"`
+	IsBindOnly        bool                      `mapstructure:"bindOnly"`
+	SubFieldsMetadata map[string]*fieldMetadata `mapstructure:"fields"`
+}
+
+type metadata struct {
+	Type                   string                    `mapstructure:"type"`
+	ExistingFieldsMetadata map[string]*fieldMetadata `mapstructure:"existingFields"`
+	NewFieldsMetadata      map[string]*fieldMetadata `mapstructure:"newFields"`
+}
+
+// parseMetadata parses and the returns the metadata represented by the provided schema.
+func parseMetadata(metadataSchema *jsonschema.Schema) (*metadata, error) {
+	md := &metadata{}
+	if err := mapstructure.Decode(*metadataSchema.Default, md); err != nil {
+		return nil, err
+	}
+
+	return md, nil
+}
+
+// mergeMetadata merges the provided metadata information in the provided node.
+func (n *Node) mergeMetadata(md *metadata) {
+	n.mergeExistingFieldsMetadata(md.ExistingFieldsMetadata)
+	n.mergeNewFieldsMetadata(md.NewFieldsMetadata)
+}
+
+// mergeExistingFieldsMetadata associates the provided fields metadata to the corresponding fields in the hierarchy
+// starting from the provided node.
+func (n *Node) mergeExistingFieldsMetadata(fieldsMetadata map[string]*fieldMetadata) {
+	if len(fieldsMetadata) == 0 {
+		return
+	}
+
+	for _, child := range n.Children {
+		for fieldName, fieldMd := range fieldsMetadata {
+			if child.Name != fieldName {
+				continue
+			}
+
+			nodeMetadata := newNodeMetadata(fieldMd)
+			child.Metadata = nodeMetadata
+			child.mergeExistingFieldsMetadata(fieldMd.SubFieldsMetadata)
+		}
+	}
+}
+
+// newNodeMetadata creates a new NodeMetadata object from the provided field metadata.
+func newNodeMetadata(fieldMd *fieldMetadata) *NodeMetadata {
+	return &NodeMetadata{
+		Type:       fieldMd.Type,
+		IsBindOnly: fieldMd.IsBindOnly,
+	}
+}
+
+// mergeNewFieldsMetadata creates, under the current node, a new pseudo nodes hierarchy reflecting the provided fields
+// metadata hierarchy.
+func (n *Node) mergeNewFieldsMetadata(fieldsMetadata map[string]*fieldMetadata) {
+	for fieldName, fieldMd := range fieldsMetadata {
+		newNode := newPseudoNode(fieldName, fieldMd)
+		newNode.mergeNewFieldsMetadata(fieldMd.SubFieldsMetadata)
+		n.PseudoChildren = append(n.PseudoChildren, newNode)
+	}
+}
+
+// newPseudoNode creates a new pseudo node with the provided name by leveraging the provided field metadata.
+func newPseudoNode(name string, fieldMd *fieldMetadata) *Node {
+	var descriptions []string
+	if fieldMd.Description != "" {
+		descriptions = append(descriptions, fieldMd.Description)
+	}
+	node := &Node{
+		Name:         name,
+		Descriptions: descriptions,
+		Pseudo:       true,
+		Metadata:     newNodeMetadata(fieldMd),
+	}
+	return node
+}
+
+// mergeSubSchema merges the provided sub-schema in the current node.
+func (n *Node) mergeSubSchema(subSchema *jsonschema.Schema, requirements []*EnumRequirement) error {
+	subSchemaNode, err := extractNode(subSchema, "", false, requirements)
+	if err != nil {
+		return fmt.Errorf("error extracting sub-schema node: %w", err)
+	}
+
+	n.mergeNode(subSchemaNode)
+	return nil
+}
+
+// mergeNode merges the provided node into the current node.
+func (n *Node) mergeNode(node *Node) {
+	n.Descriptions = append(n.Descriptions, node.Descriptions...)
+	n.JSONTypes = append(n.JSONTypes, node.JSONTypes...)
+	n.Required = n.Required || node.Required
+	n.Minimum = getMax(n.Minimum, node.Minimum)
+	n.MinLength = getMax(n.MinLength, node.MinLength)
+	n.MinItems = getMax(n.MinItems, node.MinItems)
+	n.MinProperties = getMax(n.MinProperties, node.MinProperties)
+	if n.Pattern == nil {
+		n.Pattern = node.Pattern
+	}
+	if n.Default == nil {
+		n.Default = node.Default
+	}
+	n.Examples = append(n.Examples, node.Examples...)
+	n.Children = append(n.Children, node.Children...)
+	n.PseudoChildren = append(n.PseudoChildren, node.PseudoChildren...)
+	if n.Metadata == nil {
+		n.Metadata = node.Metadata
+	}
+}
+
+// getMax returns the pointer containing the greater value. If one of the two provided pointer is nil, it returns the
+// other pointer.
+func getMax[T cmp.Ordered](a, b *T) *T {
+	if a == nil {
+		return b
+	}
+	if b == nil {
+		return a
+	}
+	if *a > *b {
+		return a
+	}
+	return b
+}
+
+// pruneChildren prunes the node tree starting at the current node by removing all nodes not encountered along the
+// provided path. (1) Pseudo nodes and (2) first-level children of the last node in the provide path are kept in the
+// resulting node tree.
+func (n *Node) pruneChildren(nodePath []string) error {
+	if len(nodePath) == 0 {
+		// Leave children of the last node untouched but prune their children.
+		children := n.Children
+		if len(children) == 0 {
+			return nil
+		}
+
+		for _, child := range children {
+			child.Children = nil
+		}
+		return nil
+	}
+
+	// Retrieve the current node's child with the next name from the node path.
+	name := nodePath[0]
+	child := n.getChild(name)
+	if child == nil {
+		return fmt.Errorf("cannot find %q", name)
+	}
+
+	// Recursively prune children of the selected child.
+	if err := child.pruneChildren(nodePath[1:]); err != nil {
+		return err
+	}
+
+	// Reduce the node list to the selected child + the list of pseudo nodes.
+	pseudoChildren := n.getPseudoChildrenExcept(name)
+	children := []*Node{child}
+	children = append(children, pseudoChildren...)
+	n.Children = children
+	return nil
+}
+
+// findChild finds and returns the child node with the provided name. If the child is not found, it returns nil.
+func (n *Node) getChild(name string) *Node {
+	for _, child := range n.Children {
+		if child.Name == name {
+			return child
+		}
+	}
+
+	return nil
+}
+
+// getPseudoChildrenExcept returns the list of pseudo children, except the ones having the provided name.
+func (n *Node) getPseudoChildrenExcept(name string) []*Node {
+	var children []*Node
+	for _, child := range n.Children {
+		if child.Pseudo && child.Name != name {
+			children = append(children, child)
+		}
+	}
+	return children
+}
+
+// rootNodeName is the root node name.
+const rootNodeName = "<root>"
+
+// Describe returns a node tree describing the fields along the path described by the provided node path. The provided
+// requirements are used to set values for nodes representing enumerated values (this can be used to "unlock" node tree
+// paths enabled only if specific values are provided for the aforementioned nodes).
+func Describe(nodePath []string, requirements []*EnumRequirement) (*Node, error) {
+	schema, err := load()
+	if err != nil {
+		return nil, fmt.Errorf("error loading schema: %w", err)
+	}
+
+	root, err := extractNode(schema, rootNodeName, true, requirements)
+	if err != nil {
+		return nil, fmt.Errorf("error extracting node tree: %w", err)
+	}
+	printNode("", root)
+
+	if err := root.pruneChildren(nodePath); err != nil {
+		return nil, fmt.Errorf("error pruning node tree: %w", err)
+	}
+	printNode("", root)
+
+	return root, nil
+}
+
+func printNode(space string, n *Node) {
+	if n == nil {
+		return
+	}
+
+	fmt.Printf("%s%s\n", space, n.Name)
+	for _, child := range n.Children {
+		printNode(space+"   ", child)
+	}
+}
+
+const metadataPropName = "x-metadata"
+
+// extractNode is the main node tree extraction function. It recursively calls itself to build the node tree
+// representing the provided schema.
+func extractNode(schema *jsonschema.Schema, name string, required bool,
+	requirements []*EnumRequirement) (*Node, error) {
+	// Initialize a new node from the current schema.
+	node := newNode(schema, name, required)
+
+	// Merge information from any schema reference using the "ref" keyword.
+	if ref := schema.Ref; ref != nil {
+		var refNode *Node
+		// Do not merge information from field binding schema other than its pattern value.
+		if ref.ID == bindingSchemaURL {
+			refNode = &Node{Pattern: getPattern(ref.Pattern)}
+		} else {
+			refNode = newNode(ref, "", false)
+		}
+		node.mergeNode(refNode)
+	}
+
+	// Extract the first applicable enum requirement and creates the new list of requirements to be propagated.
+	firstRequirement, newRequirements := evaluateNewEnumRequirements(requirements)
+
+	// Extract the current node's children.
+	var err error
+	node.Children, err = extractChildren(schema, newRequirements)
+	if err != nil {
+		return nil, fmt.Errorf("error extracting %q node's children: %w", name, err)
+	}
+
+	// Merge metadata, if present.
+	// NOTICE: metadata must be merged after extracting children.
+	if metadata, ok := schema.Properties[metadataPropName]; ok {
+		if err := node.mergeMetadataSchema(metadata); err != nil {
+			return nil, fmt.Errorf("error merging metadata schema: %w", err)
+		}
+	}
+
+	if firstRequirement == nil {
+		return node, nil
+	}
+
+	// Retrieve the sub-schema corresponding to the first applicable enum requirement and merge it if it is found.
+	key, value := firstRequirement.PathSegments[0], firstRequirement.Value
+	subSchema := getSubSchema(schema, key, value)
+	if subSchema == nil {
+		return node, nil
+	}
+
+	if err := node.mergeSubSchema(subSchema, newRequirements); err != nil {
+		return nil, fmt.Errorf("error merging sub-schema for (key: %s, value: %s): %w", key, value, err)
+	}
+
+	return node, nil
+}
+
+// newNode creates a new node from the data extracted from given schema.
+func newNode(schema *jsonschema.Schema, name string, required bool) *Node {
+	var descriptions []string
+	if description := schema.Description; description != "" {
+		descriptions = []string{description}
+	}
+
+	var types []string
+	if schema.Types != nil {
+		types = schema.Types.ToStrings()
+	}
+
+	var enum []any
+	if schema.Enum != nil {
+		enum = schema.Enum.Values
+	}
+
+	return &Node{
+		Name:          name,
+		Descriptions:  descriptions,
+		JSONTypes:     types,
+		Required:      required,
+		Minimum:       rationalToFloat64(schema.Minimum),
+		MinLength:     schema.MinLength,
+		MinItems:      schema.MinItems,
+		MinProperties: schema.MinProperties,
+		Pattern:       getPattern(schema.Pattern),
+		Default:       schema.Default,
+		Examples:      schema.Examples,
+		Enum:          enum,
+	}
+}
+
+// getPattern converts a jsonschema.Regexp into a string and returns its pointer. It returns nil if the provided pattern
+// is nil.
+func getPattern(pattern jsonschema.Regexp) *string {
+	if pattern == nil {
+		return nil
+	}
+
+	p := pattern.String()
+	return &p
+}
+
+// rationalToFloat64 converts a big.Rat value into the nearest float64 value and returns its pointer.
+func rationalToFloat64(rat *big.Rat) *float64 {
+	if rat == nil {
+		return nil
+	}
+
+	f, _ := rat.Float64()
+	return &f
+}
+
+// evaluateNewEnumRequirements returns the first applicable enum requirement (the first one with an enum path just
+// composed by one segment) and the new updated list of remaining requirements.
+func evaluateNewEnumRequirements(
+	requirements []*EnumRequirement) (firstRequirement *EnumRequirement, newRequirements []*EnumRequirement) {
+	for _, requirement := range requirements {
+		segments, value := requirement.PathSegments, requirement.Value
+		if len(segments) != 1 {
+			newRequirements = append(newRequirements, &EnumRequirement{
+				PathSegments: segments[1:],
+				Value:        requirement.Value,
+			})
+			continue
+		}
+
+		if firstRequirement == nil {
+			firstRequirement = requirement
+		} else {
+			newRequirements = append(newRequirements, &EnumRequirement{PathSegments: segments, Value: value})
+		}
+	}
+
+	return firstRequirement, newRequirements
+}
+
+// extractChildren extracts the list of nodes corresponding to the provided schema's properties.
+func extractChildren(schema *jsonschema.Schema, requirements []*EnumRequirement) ([]*Node, error) {
+	properties := getProperties(schema)
+	propertyNum := len(properties)
+	if propertyNum == 0 {
+		return nil, nil
+	}
+
+	nodes := make([]*Node, 0, propertyNum)
+	for prop, propSchema := range properties {
+		// Skip the property representing node metadata.
+		if prop == metadataPropName {
+			continue
+		}
+
+		// Generate new nodes for the property and its children.
+		required := isPropertyRequired(schema, prop)
+		node, err := extractNode(propSchema, prop, required, requirements)
+		if err != nil {
+			return nil, err
+		}
+
+		nodes = append(nodes, node)
+	}
+	return nodes, nil
+}
+
+// getProperties returns the merged nested and non-nested lists of schemas associated to the "properties" keyword. This
+// includes the properties directly available under the provided schema, or the properties accessible from "ref",
+// "items" and "items.ref" schemas.
+func getProperties(schema *jsonschema.Schema) map[string]*jsonschema.Schema {
+	properties := make(map[string]*jsonschema.Schema)
+	addProperties(properties, schema.Properties)
+	if ref := schema.Ref; ref != nil {
+		addProperties(properties, ref.Properties)
+	}
+	if items2020 := schema.Items2020; items2020 != nil {
+		addProperties(properties, getProperties(items2020))
+	}
+	return properties
+}
+
+// addProperties add the provided source properties to the destination properties.
+func addProperties(dstProperties, srcProperties map[string]*jsonschema.Schema) {
+	for prop, propSchema := range srcProperties {
+		dstProperties[prop] = propSchema
+	}
+}
+
+// isPropertyRequired returns true if the property with the provided name is required in the provided containing schema.
+func isPropertyRequired(schema *jsonschema.Schema, prop string) bool {
+	for _, req := range schema.Required {
+		if prop == req {
+			return true
+		}
+	}
+
+	return false
+}
+
+// getSubSchema returns the sub-schema of the provided schema corresponding to the provided key-value couple, if
+// present; otherwise it returns nil. The returned sub-schema is the "then" schema corresponding to the "if" schema
+// requiring the provided value for the provided key (i.e: property).
+func getSubSchema(schema *jsonschema.Schema, subSchemaKey, subSchemaValue string) *jsonschema.Schema {
+	for _, allOfSchema := range getAllOf(schema) {
+		p, ok := allOfSchema.If.Properties[subSchemaKey]
+		if !ok {
+			continue
+		}
+
+		c := p.Const
+		if c == nil {
+			continue
+		}
+
+		if s, ok := (*c).(string); ok && s == subSchemaValue {
+			return allOfSchema.Then.Ref
+		}
+	}
+	return nil
+}
+
+// getAllOf returns the merged nested and non-nested lists of schemas associated to the "allOf" keyword. This includes
+// the "allOf" schemas directly available under the provided schema, or the ones accessible from "ref", "items" and
+// "items.ref" schemas.
+func getAllOf(schema *jsonschema.Schema) []*jsonschema.Schema {
+	var allOf []*jsonschema.Schema
+	allOf = append(allOf, schema.AllOf...)
+	if ref := schema.Ref; ref != nil {
+		allOf = append(allOf, ref.AllOf...)
+	}
+	if items2020 := schema.Items2020; items2020 != nil {
+		allOf = append(allOf, getAllOf(items2020)...)
+	}
+	return allOf
+}

--- a/pkg/test/loader/schema/jsonschemas/expectedOutcome.schema.json
+++ b/pkg/test/loader/schema/jsonschemas/expectedOutcome.schema.json
@@ -4,34 +4,36 @@
   "title": "Test expected outcome",
   "description": "The outcome expected from Falco as a result of the test execution",
   "type": "object",
-  "source": {
-    "description": "The Falco event source",
-    "type": "string",
-    "minLength": 1,
-    "examples": [
-      "syscall"
-    ]
-  },
-  "hostname": {
-    "description": "The Falco event hostname",
-    "type": "string",
-    "minLength": 1
-  },
-  "priority": {
-    "description": "The Falco event priority",
-    "type": "string",
-    "minLength": 1,
-    "examples": [
-      "WARNING"
-    ]
-  },
-  "outputFields": {
-    "description": "The output fields attached to the Falco event",
-    "type": "object",
-    "minProperties": 1,
-    "additionalProperties": {
+  "properties": {
+    "source": {
+      "description": "The Falco event source",
+      "type": "string",
+      "minLength": 1,
+      "examples": [
+        "syscall"
+      ]
+    },
+    "hostname": {
+      "description": "The Falco event hostname",
       "type": "string",
       "minLength": 1
+    },
+    "priority": {
+      "description": "The Falco event priority",
+      "type": "string",
+      "minLength": 1,
+      "examples": [
+        "WARNING"
+      ]
+    },
+    "outputFields": {
+      "description": "The output fields attached to the Falco event",
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": {
+        "type": "string",
+        "minLength": 1
+      }
     }
   }
 }

--- a/pkg/test/loader/schema/jsonschemas/resources/clientServer.schema.json
+++ b/pkg/test/loader/schema/jsonschemas/resources/clientServer.schema.json
@@ -18,6 +18,32 @@
     "address": {
       "description": "The endpoint exposed by the server (as accepted by net.SplitHostPort or empty, in case of l4Proto equals to 'unix'",
       "type": "string"
+    },
+    "x-metadata": {
+      "not": {},
+      "type": "object",
+      "default": {
+        "newFields": {
+          "client": {
+            "description": "The exposed client information",
+            "fields": {
+              "fd": {
+                "description": "The client file descriptor",
+                "fieldType": "fd"
+              }
+            }
+          },
+          "server": {
+            "description": "The exposed server information",
+            "fields": {
+              "fd": {
+                "description": "The server file descriptor",
+                "fieldType": "fd"
+              }
+            }
+          }
+        }
+      }
     }
   },
   "required": [

--- a/pkg/test/loader/schema/jsonschemas/resources/fd/directory.schema.json
+++ b/pkg/test/loader/schema/jsonschemas/resources/fd/directory.schema.json
@@ -8,6 +8,18 @@
       "description": "The directory path",
       "type": "string",
       "minLength": 1
+    },
+    "x-metadata": {
+      "not": {},
+      "type": "object",
+      "default": {
+        "newFields": {
+          "fd": {
+            "description": "The directory file descriptor",
+            "fieldType": "fd"
+          }
+        }
+      }
     }
   },
   "required": [

--- a/pkg/test/loader/schema/jsonschemas/resources/fd/event.schema.json
+++ b/pkg/test/loader/schema/jsonschemas/resources/fd/event.schema.json
@@ -2,5 +2,19 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "resources.fd.event.schema.json",
   "title": "The event fd test resource",
-  "description": "An event fd test resource creates an event fd and exposes it"
+  "description": "An event fd test resource creates an event fd and exposes it",
+  "properties": {
+    "x-metadata": {
+      "not": {},
+      "type": "object",
+      "default": {
+        "newFields": {
+          "fd": {
+            "description": "The event file descriptor",
+            "fieldType": "fd"
+          }
+        }
+      }
+    }
+  }
 }

--- a/pkg/test/loader/schema/jsonschemas/resources/fd/eventpoll.schema.json
+++ b/pkg/test/loader/schema/jsonschemas/resources/fd/eventpoll.schema.json
@@ -2,5 +2,19 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "resources.fd.eventpoll.schema.json",
   "title": "The eventpoll fd test resource",
-  "description": "An eventpoll fd test resource creates an epoll fd and exposes it"
+  "description": "An eventpoll fd test resource creates an epoll fd and exposes it",
+  "properties": {
+    "x-metadata": {
+      "not": {},
+      "type": "object",
+      "default": {
+        "newFields": {
+          "fd": {
+            "description": "The epoll file descriptor",
+            "fieldType": "fd"
+          }
+        }
+      }
+    }
+  }
 }

--- a/pkg/test/loader/schema/jsonschemas/resources/fd/file.schema.json
+++ b/pkg/test/loader/schema/jsonschemas/resources/fd/file.schema.json
@@ -8,6 +8,18 @@
       "description": "The regular file path",
       "type": "string",
       "minLength": 1
+    },
+    "x-metadata": {
+      "not": {},
+      "type": "object",
+      "default": {
+        "newFields": {
+          "fd": {
+            "description": "The regular file descriptor",
+            "fieldType": "fd"
+          }
+        }
+      }
     }
   },
   "required": [

--- a/pkg/test/loader/schema/jsonschemas/resources/fd/inotify.schema.json
+++ b/pkg/test/loader/schema/jsonschemas/resources/fd/inotify.schema.json
@@ -2,5 +2,19 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "resources.fd.inotify.schema.json",
   "title": "The inotify fd test resource",
-  "description": "An inotify fd test resource creates an inotify fd and exposes it"
+  "description": "An inotify fd test resource creates an inotify fd and exposes it",
+  "properties": {
+    "x-metadata": {
+      "not": {},
+      "type": "object",
+      "default": {
+        "newFields": {
+          "fd": {
+            "description": "The inotify instance file descriptor",
+            "fieldType": "fd"
+          }
+        }
+      }
+    }
+  }
 }

--- a/pkg/test/loader/schema/jsonschemas/resources/fd/memfd.schema.json
+++ b/pkg/test/loader/schema/jsonschemas/resources/fd/memfd.schema.json
@@ -2,5 +2,19 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "resources.fd.memfd.schema.json",
   "title": "The memfd fd test resource",
-  "description": "A memfd fd test resource creates a mem fd and exposes it"
+  "description": "A memfd fd test resource creates a mem fd and exposes it",
+  "properties": {
+    "x-metadata": {
+      "not": {},
+      "type": "object",
+      "default": {
+        "newFields": {
+          "fd": {
+            "description": "The mem file descriptor",
+            "fieldType": "fd"
+          }
+        }
+      }
+    }
+  }
 }

--- a/pkg/test/loader/schema/jsonschemas/resources/fd/pipe.schema.json
+++ b/pkg/test/loader/schema/jsonschemas/resources/fd/pipe.schema.json
@@ -2,5 +2,23 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "resources.fd.pipe.schema.json",
   "title": "The pipe fd test resource",
-  "description": "A pipe fd test resource creates a pipe and exposes its file descriptors"
+  "description": "A pipe fd test resource creates a pipe and exposes its file descriptors",
+  "properties": {
+    "x-metadata": {
+      "not": {},
+      "type": "object",
+      "default": {
+        "newFields": {
+          "readFd": {
+            "description": "the pipe's read end file descriptor",
+            "fieldType": "fd"
+          },
+          "writeFd": {
+            "description": "the pipe's write end file descriptor",
+            "fieldType": "fd"
+          }
+        }
+      }
+    }
+  }
 }

--- a/pkg/test/loader/schema/jsonschemas/resources/fd/signalfd.schema.json
+++ b/pkg/test/loader/schema/jsonschemas/resources/fd/signalfd.schema.json
@@ -2,5 +2,19 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "resources.fd.signalfd.schema.json",
   "title": "The signalfd fd test resource",
-  "description": "A signalfd fd test resource creates a signal fd and exposes it"
+  "description": "A signalfd fd test resource creates a signal fd and exposes it",
+  "properties": {
+    "x-metadata": {
+      "not": {},
+      "type": "object",
+      "default": {
+        "newFields": {
+          "fd": {
+            "description": "The signal file descriptor",
+            "fieldType": "fd"
+          }
+        }
+      }
+    }
+  }
 }

--- a/pkg/test/loader/schema/jsonschemas/resources/process.schema.json
+++ b/pkg/test/loader/schema/jsonschemas/resources/process.schema.json
@@ -38,6 +38,18 @@
         "type": "string",
         "minLength": 1
       }
+    },
+    "x-metadata": {
+      "not": {},
+      "type": "object",
+      "default": {
+        "newFields": {
+          "pid": {
+            "description": "The process identifier",
+            "fieldType": "pid"
+          }
+        }
+      }
     }
   }
 }

--- a/pkg/test/loader/schema/jsonschemas/steps/syscalls/connect.schema.json
+++ b/pkg/test/loader/schema/jsonschemas/steps/syscalls/connect.schema.json
@@ -32,6 +32,30 @@
         "fd",
         "address"
       ]
+    },
+    "x-metadata": {
+      "not": {},
+      "type": "object",
+      "default": {
+        "existingFields": {
+          "args": {
+            "fields": {
+              "fd": {
+                "fieldType": "fd"
+              },
+              "address": {
+                "fieldType": "socket_address"
+              }
+            }
+          }
+        },
+        "newFields": {
+          "ret": {
+            "description": "The connect system call return value",
+            "fieldType": "-"
+          }
+        }
+      }
     }
   },
   "required": [

--- a/pkg/test/loader/schema/jsonschemas/steps/syscalls/dup.schema.json
+++ b/pkg/test/loader/schema/jsonschemas/steps/syscalls/dup.schema.json
@@ -21,6 +21,27 @@
       "required": [
         "oldFd"
       ]
+    },
+    "x-metadata": {
+      "not": {},
+      "type": "object",
+      "default": {
+        "existingFields": {
+          "args": {
+            "fields": {
+              "oldFd": {
+                "fieldType": "fd"
+              }
+            }
+          }
+        },
+        "newFields": {
+          "ret": {
+            "description": "The dup system call return value",
+            "fieldType": "fd"
+          }
+        }
+      }
     }
   },
   "required": [

--- a/pkg/test/loader/schema/jsonschemas/steps/syscalls/dup2.schema.json
+++ b/pkg/test/loader/schema/jsonschemas/steps/syscalls/dup2.schema.json
@@ -31,6 +31,30 @@
         "oldFd",
         "newFd"
       ]
+    },
+    "x-metadata": {
+      "not": {},
+      "type": "object",
+      "default": {
+        "existingFields": {
+          "args": {
+            "fields": {
+              "oldFd": {
+                "fieldType": "fd"
+              },
+              "newFd": {
+                "fieldType": "fd"
+              }
+            }
+          }
+        },
+        "newFields": {
+          "ret": {
+            "description": "The dup2 system call return value",
+            "fieldType": "fd"
+          }
+        }
+      }
     }
   },
   "required": [

--- a/pkg/test/loader/schema/jsonschemas/steps/syscalls/dup3.schema.json
+++ b/pkg/test/loader/schema/jsonschemas/steps/syscalls/dup3.schema.json
@@ -43,6 +43,33 @@
         "oldFd",
         "newFd"
       ]
+    },
+    "x-metadata": {
+      "not": {},
+      "type": "object",
+      "default": {
+        "existingFields": {
+          "args": {
+            "fields": {
+              "oldFd": {
+                "fieldType": "fd"
+              },
+              "newFd": {
+                "fieldType": "fd"
+              },
+              "flags": {
+                "fieldType": "dup3_flags"
+              }
+            }
+          }
+        },
+        "newFields": {
+          "ret": {
+            "description": "The dup3 system call return value",
+            "fieldType": "fd"
+          }
+        }
+      }
     }
   },
   "required": [

--- a/pkg/test/loader/schema/jsonschemas/steps/syscalls/finitModule.schema.json
+++ b/pkg/test/loader/schema/jsonschemas/steps/syscalls/finitModule.schema.json
@@ -40,6 +40,34 @@
       "required": [
         "fd"
       ]
+    },
+    "x-metadata": {
+      "not": {},
+      "type": "object",
+      "default": {
+        "existingFields": {
+          "args": {
+            "fields": {
+              "fd": {
+                "fieldType": "fd",
+                "bindOnly": true
+              },
+              "paramValues": {
+                "fieldType": "module_params"
+              },
+              "flags": {
+                "fieldType": "finit_module_flags"
+              }
+            }
+          }
+        },
+        "newFields": {
+          "ret": {
+            "description": "The finit_module system call return value",
+            "fieldType": "-"
+          }
+        }
+      }
     }
   },
   "required": [

--- a/pkg/test/loader/schema/jsonschemas/steps/syscalls/initModule.schema.json
+++ b/pkg/test/loader/schema/jsonschemas/steps/syscalls/initModule.schema.json
@@ -28,6 +28,30 @@
       "required": [
         "moduleImage"
       ]
+    },
+    "x-metadata": {
+      "not": {},
+      "type": "object",
+      "default": {
+        "existingFields": {
+          "args": {
+            "fields": {
+              "moduleImage": {
+                "fieldType": "buffer"
+              },
+              "paramValues": {
+                "fieldType": "module_params"
+              }
+            }
+          }
+        },
+        "newFields": {
+          "ret": {
+            "description": "The init_module system call return value",
+            "fieldType": "-"
+          }
+        }
+      }
     }
   },
   "required": [

--- a/pkg/test/loader/schema/jsonschemas/steps/syscalls/kill.schema.json
+++ b/pkg/test/loader/schema/jsonschemas/steps/syscalls/kill.schema.json
@@ -31,6 +31,31 @@
         "pid",
         "sig"
       ]
+    },
+    "x-metadata": {
+      "not": {},
+      "type": "object",
+      "default": {
+        "existingFields": {
+          "args": {
+            "fields": {
+              "pid": {
+                "fieldType": "pid",
+                "bindOnly": true
+              },
+              "sig": {
+                "fieldType": "signal"
+              }
+            }
+          }
+        },
+        "newFields": {
+          "ret": {
+            "description": "The kill system call return value",
+            "fieldType": "-"
+          }
+        }
+      }
     }
   },
   "required": [

--- a/pkg/test/loader/schema/jsonschemas/steps/syscalls/link.schema.json
+++ b/pkg/test/loader/schema/jsonschemas/steps/syscalls/link.schema.json
@@ -33,6 +33,30 @@
         "oldPath",
         "newPath"
       ]
+    },
+    "x-metadata": {
+      "not": {},
+      "type": "object",
+      "default": {
+        "existingFields": {
+          "args": {
+            "fields": {
+              "oldPath": {
+                "fieldType": "file_path"
+              },
+              "newPath": {
+                "fieldType": "file_path"
+              }
+            }
+          }
+        },
+        "newFields": {
+          "ret": {
+            "description": "The link system call return value",
+            "fieldType": "-"
+          }
+        }
+      }
     }
   },
   "required": [

--- a/pkg/test/loader/schema/jsonschemas/steps/syscalls/linkAt.schema.json
+++ b/pkg/test/loader/schema/jsonschemas/steps/syscalls/linkAt.schema.json
@@ -67,6 +67,41 @@
         "newDirFd",
         "newPath"
       ]
+    },
+    "x-metadata": {
+      "not": {},
+      "type": "object",
+      "default": {
+        "existingFields": {
+          "args": {
+            "fields": {
+              "oldDirFd": {
+                "fieldType": "fd",
+                "bindOnly": true
+              },
+              "oldPath": {
+                "fieldType": "file_path"
+              },
+              "newDirFd": {
+                "fieldType": "fd",
+                "bindOnly":  true
+              },
+              "newPath": {
+                "fieldType": "file_path"
+              },
+              "flags": {
+                "fieldType": "linkat_flags"
+              }
+            }
+          }
+        },
+        "newFields": {
+          "ret": {
+            "description": "The linkat system call return value",
+            "fieldType": "-"
+          }
+        }
+      }
     }
   },
   "required": [

--- a/pkg/test/loader/schema/jsonschemas/steps/syscalls/open.schema.json
+++ b/pkg/test/loader/schema/jsonschemas/steps/syscalls/open.schema.json
@@ -46,6 +46,33 @@
         "pathname",
         "flags"
       ]
+    },
+    "x-metadata": {
+      "not": {},
+      "type": "object",
+      "default": {
+        "existingFields": {
+          "args": {
+            "fields": {
+              "pathname": {
+                "fieldType": "file_path"
+              },
+              "flags": {
+                "fieldType": "open_flags"
+              },
+              "mode": {
+                "fieldType": "open_mode"
+              }
+            }
+          }
+        },
+        "newFields": {
+          "ret": {
+            "description": "The open system call return value",
+            "fieldType": "fd"
+          }
+        }
+      }
     }
   },
   "required": [

--- a/pkg/test/loader/schema/jsonschemas/steps/syscalls/openAt.schema.json
+++ b/pkg/test/loader/schema/jsonschemas/steps/syscalls/openAt.schema.json
@@ -56,6 +56,37 @@
         "pathname",
         "flags"
       ]
+    },
+    "x-metadata": {
+      "not": {},
+      "type": "object",
+      "default": {
+        "existingFields": {
+          "args": {
+            "fields": {
+              "dirFd": {
+                "fieldType": "fd",
+                "bindOnly": true
+              },
+              "pathname": {
+                "fieldType": "file_path"
+              },
+              "flags": {
+                "fieldType": "open_flags"
+              },
+              "mode": {
+                "fieldType": "open_mode"
+              }
+            }
+          }
+        },
+        "newFields": {
+          "ret": {
+            "description": "The openat system call return value",
+            "fieldType": "fd"
+          }
+        }
+      }
     }
   },
   "required": [

--- a/pkg/test/loader/schema/jsonschemas/steps/syscalls/openAt2.schema.json
+++ b/pkg/test/loader/schema/jsonschemas/steps/syscalls/openAt2.schema.json
@@ -71,6 +71,45 @@
         "dirFd",
         "pathname"
       ]
+    },
+    "x-metadata": {
+      "not": {},
+      "type": "object",
+      "default": {
+        "existingFields": {
+          "args": {
+            "fields": {
+              "dirFd": {
+                "fieldType": "fd",
+                "bindOnly": true
+              },
+              "pathname": {
+                "fieldType": "file_path"
+              },
+              "how": {
+                "fieldType": "open_how",
+                "fields": {
+                  "flags": {
+                    "fieldType": "open_how_flags"
+                  },
+                  "mode": {
+                    "fieldType": "open_how_mode"
+                  },
+                  "resolve": {
+                    "fieldType": "open_how_resolve"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "newFields": {
+          "ret": {
+            "description": "The openat2 system call return value",
+            "fieldType": "fd"
+          }
+        }
+      }
     }
   },
   "required": [

--- a/pkg/test/loader/schema/jsonschemas/steps/syscalls/read.schema.json
+++ b/pkg/test/loader/schema/jsonschemas/steps/syscalls/read.schema.json
@@ -37,6 +37,33 @@
       "required": [
         "fd"
       ]
+    },
+    "x-metadata": {
+      "not": {},
+      "type": "object",
+      "default": {
+        "existingFields": {
+          "args": {
+            "fields": {
+              "fd": {
+                "fieldType": "fd"
+              },
+              "buffer": {
+                "fieldType": "buffer"
+              },
+              "len": {
+                "fieldType": "buffer_len"
+              }
+            }
+          }
+        },
+        "newFields": {
+          "ret": {
+            "description": "The read system call return value",
+            "fieldType": "fd"
+          }
+        }
+      }
     }
   },
   "required": [

--- a/pkg/test/loader/schema/jsonschemas/steps/syscalls/sendTo.schema.json
+++ b/pkg/test/loader/schema/jsonschemas/steps/syscalls/sendTo.schema.json
@@ -59,6 +59,40 @@
         "flags",
         "destAddr"
       ]
+    },
+    "x-metadata": {
+      "not": {},
+      "type": "object",
+      "default": {
+        "existingFields": {
+          "args": {
+            "fields": {
+              "fd": {
+                "fieldType": "fd",
+                "bindOnly": true
+              },
+              "buf": {
+                "fieldType": "buffer"
+              },
+              "len": {
+                "fieldType": "buffer_len"
+              },
+              "flags": {
+                "fieldType": "send_flags"
+              },
+              "destAddr": {
+                "fieldType": "socket_address"
+              }
+            }
+          }
+        },
+        "newFields": {
+          "ret": {
+            "description": "The sendto system call return value",
+            "fieldType": "-"
+          }
+        }
+      }
     }
   },
   "required": [

--- a/pkg/test/loader/schema/jsonschemas/steps/syscalls/socket.schema.json
+++ b/pkg/test/loader/schema/jsonschemas/steps/syscalls/socket.schema.json
@@ -51,6 +51,33 @@
         "type",
         "protocol"
       ]
+    },
+    "x-metadata": {
+      "not": {},
+      "type": "object",
+      "default": {
+        "existingFields": {
+          "args": {
+            "fields": {
+              "domain": {
+                "fieldType": "socket_domain"
+              },
+              "type": {
+                "fieldType": "socket_type"
+              },
+              "protocol": {
+                "fieldType": "socket_protocol"
+              }
+            }
+          }
+        },
+        "newFields": {
+          "ret": {
+            "description": "The socket system call return value",
+            "fieldType": "fd"
+          }
+        }
+      }
     }
   },
   "required": [

--- a/pkg/test/loader/schema/jsonschemas/steps/syscalls/symLink.schema.json
+++ b/pkg/test/loader/schema/jsonschemas/steps/syscalls/symLink.schema.json
@@ -33,6 +33,30 @@
         "target",
         "linkPath"
       ]
+    },
+    "x-metadata": {
+      "not": {},
+      "type": "object",
+      "default": {
+        "existingFields": {
+          "args": {
+            "fields": {
+              "target": {
+                "fieldType": "file_path"
+              },
+              "linkPath": {
+                "fieldType": "file_path"
+              }
+            }
+          }
+        },
+        "newFields": {
+          "ret": {
+            "description": "The symlink system call return value",
+            "fieldType": "-"
+          }
+        }
+      }
     }
   },
   "required": [

--- a/pkg/test/loader/schema/jsonschemas/steps/syscalls/symLinkAt.schema.json
+++ b/pkg/test/loader/schema/jsonschemas/steps/syscalls/symLinkAt.schema.json
@@ -44,6 +44,34 @@
         "newDirFd",
         "linkPath"
       ]
+    },
+    "x-metadata": {
+      "not": {},
+      "type": "object",
+      "default": {
+        "existingFields": {
+          "args": {
+            "fields": {
+              "target": {
+                "fieldType": "file_path"
+              },
+              "newDirFd": {
+                "fieldType": "fd",
+                "bindOnly": true
+              },
+              "linkPath": {
+                "fieldType": "file_path"
+              }
+            }
+          }
+        },
+        "newFields": {
+          "ret": {
+            "description": "The syscall system call return value",
+            "fieldType": "-"
+          }
+        }
+      }
     }
   },
   "required": [

--- a/pkg/test/loader/schema/jsonschemas/steps/syscalls/write.schema.json
+++ b/pkg/test/loader/schema/jsonschemas/steps/syscalls/write.schema.json
@@ -36,6 +36,33 @@
       "required": [
         "fd"
       ]
+    },
+    "x-metadata": {
+      "not": {},
+      "type": "object",
+      "default": {
+        "existingFields": {
+          "args": {
+            "fields": {
+              "fd": {
+                "fieldType": "fd"
+              },
+              "buffer": {
+                "fieldType": "buffer"
+              },
+              "len": {
+                "fieldType": "buffer_len"
+              }
+            }
+          }
+        },
+        "newFields": {
+          "ret": {
+            "description": "The write system call return value",
+            "fieldType": "buffer_len"
+          }
+        }
+      }
     }
   },
   "required": [

--- a/pkg/test/loader/schema/schema.go
+++ b/pkg/test/loader/schema/schema.go
@@ -101,13 +101,17 @@ var (
 	expectedOutcomeSchema string
 )
 
-// rootSchema is the identifier of the root schema.
-var rootSchema = "description.schema.json"
+var (
+	// rootSchemaURL is the identifier of the root schema.
+	rootSchemaURL = "description.schema.json"
+	// rootSchemaURL is the identifier of the binding schema.
+	bindingSchemaURL = "binding.schema.json"
+)
 
 // schemas associated to each schema identifier the corresponding schema.
 var schemas = map[string]string{
-	rootSchema:                              descriptionSchema,
-	"binding.schema.json":                   bindingSchema,
+	rootSchemaURL:                           descriptionSchema,
+	bindingSchemaURL:                        bindingSchema,
 	"test.schema.json":                      testSchema,
 	"context.schema.json":                   contextSchema,
 	"resource.schema.json":                  resourceSchema,
@@ -145,16 +149,6 @@ var schemas = map[string]string{
 	"expectedOutcome.schema.json":           expectedOutcomeSchema,
 }
 
-// Validate validates the provided object against the schema.
-func Validate(obj any) error {
-	schema, err := load()
-	if err != nil {
-		return fmt.Errorf("error loading schema: %w", err)
-	}
-
-	return schema.Validate(obj)
-}
-
 // load loads the schema.
 func load() (*jsonschema.Schema, error) {
 	compiler := jsonschema.NewCompiler()
@@ -169,7 +163,7 @@ func load() (*jsonschema.Schema, error) {
 		}
 	}
 
-	schema, err := compiler.Compile(rootSchema)
+	schema, err := compiler.Compile(rootSchemaURL)
 	if err != nil {
 		return nil, fmt.Errorf("error compiling: %w", err)
 	}

--- a/pkg/test/loader/schema/validate.go
+++ b/pkg/test/loader/schema/validate.go
@@ -13,6 +13,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package schema provides validation for the loaded tests description and documentation generation leveraging JSON
-// schemas.
 package schema
+
+import "fmt"
+
+// Validate validates the provided object against the schema.
+func Validate(obj any) error {
+	schema, err := load()
+	if err != nil {
+		return fmt.Errorf("error loading schema: %w", err)
+	}
+
+	return schema.Validate(obj)
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note: it's really useful for the changelog!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind documentation

> /kind tests

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area commands

/area pkg

> /area events

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR adds support for generating a documentation node tree from JSON schema.

Each node in the tree represents a property of the JSON schema. Some nodes are not present in the original JSON schema, but are added to augment the information provided: these nodes are called "pseudo" nodes.

The main introduced `schema.Describe` function generates a node tree by taking into account the provided node path and an optional list of enum requirements. An enum requirement specifies the node path to an enumerated value in the node tree and the corresponding value to set: setting a value for an enumerated node can "unlock" further nodes in the tree.

In order to add additional information with the respect to the one encoded in the standard JSON schema, the PR adds some "metadata" to the JSON schema. These metadata are encoded as `x-metadata` properties, but are not interpreted as normal properties: they are extracted and used to fill information for other nodes in the tree or create new pseudo nodes. 

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

