### PR TITLE
fix(decl/cmd/test): wait for goroutines termination upon failures

### DIFF
--- a/pkg/test/tester/tester/tester.go
+++ b/pkg/test/tester/tester/tester.go
@@ -65,7 +65,7 @@ func (t *testerImpl) StartAlertsCollection(ctx context.Context) error {
 	}
 
 	alertInfoCh := t.filterAlertsWithUID(ctx, alertCh)
-	t.startAlertsCaching(ctx, alertInfoCh)
+	t.startAlertsCaching(alertInfoCh)
 	return nil
 }
 
@@ -142,17 +142,9 @@ func (t *testerImpl) findUID(alrt *alert.Alert) *uuid.UUID {
 }
 
 // startAlertsCaching starts caching the alerts received through the provided channel.
-func (t *testerImpl) startAlertsCaching(ctx context.Context, alertInfoCh <-chan *alertInfo) {
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case info, ok := <-alertInfoCh:
-			if !ok {
-				return
-			}
-			t.cacheAlert(info.uid, info.alert)
-		}
+func (t *testerImpl) startAlertsCaching(alertInfoCh <-chan *alertInfo) {
+	for info := range alertInfoCh {
+		t.cacheAlert(info.uid, info.alert)
 	}
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note: it's really useful for the changelog!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind documentation

> /kind tests

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area commands

> /area pkg

> /area events

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR fixes the `test` command termination handling upon failures. Specifically, now the command waits for goroutines termination before terminating the process.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #254 

**Special notes for your reviewer**:

