### PR TITLE
feat(decl): make `rule` and `expectedOutcome` conditionally optional

### DIFF
--- a/pkg/test/loader/loader.go
+++ b/pkg/test/loader/loader.go
@@ -345,16 +345,16 @@ func (c *Description) validate() error {
 
 // Test is a rule test description.
 type Test struct {
-	Rule            string              `yaml:"rule" mapstructure:"rule"`
-	Name            string              `yaml:"name" mapstructure:"name"`
-	Description     *string             `yaml:"description,omitempty" mapstructure:"description"`
-	Runner          TestRunnerType      `yaml:"runner" mapstructure:"runner"`
-	Context         *TestContext        `yaml:"context,omitempty" mapstructure:"context"`
-	BeforeScript    *string             `yaml:"before,omitempty" mapstructure:"before"`
-	AfterScript     *string             `yaml:"after,omitempty" mapstructure:"after"`
-	Resources       []TestResource      `yaml:"resources,omitempty" mapstructure:"resources"`
-	Steps           []TestStep          `yaml:"steps,omitempty" mapstructure:"steps"`
-	ExpectedOutcome TestExpectedOutcome `yaml:"expectedOutcome" mapstructure:"expectedOutcome"`
+	Rule            *string              `yaml:"rule,omitempty" mapstructure:"rule"`
+	Name            string               `yaml:"name" mapstructure:"name"`
+	Description     *string              `yaml:"description,omitempty" mapstructure:"description"`
+	Runner          TestRunnerType       `yaml:"runner" mapstructure:"runner"`
+	Context         *TestContext         `yaml:"context,omitempty" mapstructure:"context"`
+	BeforeScript    *string              `yaml:"before,omitempty" mapstructure:"before"`
+	AfterScript     *string              `yaml:"after,omitempty" mapstructure:"after"`
+	Resources       []TestResource       `yaml:"resources,omitempty" mapstructure:"resources"`
+	Steps           []TestStep           `yaml:"steps,omitempty" mapstructure:"steps"`
+	ExpectedOutcome *TestExpectedOutcome `yaml:"expectedOutcome,omitempty" mapstructure:"expectedOutcome"`
 }
 
 // validateNameUniqueness validates that names used for test resources and steps are unique.

--- a/pkg/test/loader/schema/jsonschemas/expectedOutcome.schema.json
+++ b/pkg/test/loader/schema/jsonschemas/expectedOutcome.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "expectedOutcome.schema.json",
   "title": "Test expected outcome",
-  "description": "The outcome expected from Falco as a result of the test execution",
+  "description": "The outcome expected from Falco as a result of the test execution. It is only taken into account when running the test through the 'test' command. If not provided, it matches any outcome resulting from the application of the test actions",
   "type": "object",
   "properties": {
     "source": {

--- a/pkg/test/loader/schema/jsonschemas/test.schema.json
+++ b/pkg/test/loader/schema/jsonschemas/test.schema.json
@@ -6,7 +6,7 @@
   "type": "object",
   "properties": {
     "rule": {
-      "description": "The rule name",
+      "description": "The rule name. It is only required when running the test through the 'test' command",
       "type": "string",
       "minLength": 1
     },
@@ -61,9 +61,7 @@
     }
   },
   "required": [
-    "rule",
     "name",
-    "runner",
-    "expectedOutcome"
+    "runner"
   ]
 }

--- a/pkg/test/tester/tester.go
+++ b/pkg/test/tester/tester.go
@@ -28,7 +28,8 @@ type Tester interface {
 	// StartAlertsCollection starts the process of alerts collection.
 	StartAlertsCollection(ctx context.Context) error
 	// Report returns a report containing information regarding the alerts matching or not matching the provided
-	// expected outcome for the provided rule.
+	// expected outcome for the provided rule. A nil or empty expected outcome matches any alert corresponding to the
+	// provided rule.
 	Report(uid *uuid.UUID, rule string, expectedOutcome *loader.TestExpectedOutcome) *Report
 }
 

--- a/pkg/test/tester/tester/tester.go
+++ b/pkg/test/tester/tester/tester.go
@@ -173,10 +173,17 @@ func (t *testerImpl) Report(uid *uuid.UUID, rule string, expectedOutcome *loader
 }
 
 // accountAlert accounts the provided alert in the provided report, by matching it against the provided expected outcome
-// for the provided rule.
+// for the provided rule. If the provided expected outcome is nil or empty, and the alert is generated for the requested
+// rule, it is accounted as a successful match.
 func accountAlert(report *tester.Report, reportRule string, alrt *alert.Alert,
 	expectedOutcome *loader.TestExpectedOutcome) {
 	if alrt.Rule != reportRule {
+		return
+	}
+
+	// A nil expected outcome matches any alert.
+	if expectedOutcome == nil {
+		report.SuccessfulMatches++
 		return
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note: it's really useful for the changelog!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind documentation

> /kind tests

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area commands

/area pkg

> /area events

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR conditionally makes the `rule` and `expectedOutcome` fields optional in the YAML tests description.
If the user run a test through the `declarative run` command or, equivalently, the `declarative test --skip-outcome-verification` command, these  fields are ignored.
If the user run a test through `declarative test` command, the `rule` field is mandatory, and an empty `expectedOutcome` matches any outcome resulting from the application of the test actions.
 
**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #257 

**Special notes for your reviewer**:

