### PR TITLE
feat(decl/loader): allow spaces in field binding syntax

### DIFF
--- a/pkg/test/loader/loader.go
+++ b/pkg/test/loader/loader.go
@@ -231,7 +231,7 @@ func decodeTestStep(fromType, toType reflect.Type, from any) (any, error) {
 	return testStep, nil
 }
 
-var fieldBindingRegex = regexp.MustCompile(`^\${(.+?)\.(.+)}$`)
+var fieldBindingRegex = regexp.MustCompile(`^\s*\${\s*(\S+?)\.(\S+)\s*}\s*$`)
 
 // getFieldBindings returns the field bindings found in the provided arguments.
 func getFieldBindings(containingArgName string, args map[string]any) []*TestStepFieldBinding {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note: it's really useful for the changelog!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind documentation

> /kind tests

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area commands

/area pkg

> /area events

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR relaxes field binding syntax by allowing any number of spaces to be placed in the positions specified by the following expression (spaces are allowed where the `<space>` placeholder is present): `"<space>${<space><fieldBindingExpr><space}<space>"`

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

