### PR TITLE
feat(decl/cmd/test): groups test reports by test suite 

### DIFF
--- a/pkg/test/tester/tester.go
+++ b/pkg/test/tester/tester.go
@@ -37,7 +37,7 @@ type Tester interface {
 // rule.
 type Report struct {
 	TestName          string          `json:"test" yaml:"test"`
-	RuleName          string          `json:"rule" yaml:"rule"`
+	RuleName          string          `json:"-" yaml:"-"`
 	SuccessfulMatches int             `json:"successfulMatches" yaml:"successfulMatches"`
 	GeneratedWarnings []ReportWarning `json:"generatedWarnings,omitempty" yaml:"generatedWarnings,omitempty"`
 }
@@ -59,10 +59,4 @@ type ReportFieldWarning struct {
 	Field    string `json:"field" yaml:"field"`
 	Expected any    `json:"expected" yaml:"expected"`
 	Got      any    `json:"got" yaml:"got"`
-}
-
-// ReportEncoder allows to encode a report.
-type ReportEncoder interface {
-	// Encode encodes the provided report with a specific format and write it to the underlying destination.
-	Encode(report *Report) error
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note: it's really useful for the changelog!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind documentation

> /kind tests

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area commands

/area pkg

> /area events

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR restructures the `cmd/test` code to change the way test results are collected and printed. Test reports are now collected by test suite and printed all together. Moreover, a failure in the execution of a single test doesn't prevent anymore the execution of the other tests, as the test is simply accounted as failed.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #252 

**Special notes for your reviewer**:

