### PR TITLE
feat(decl/suite): reorganize `suite` package and add test suite report encoders

### DIFF
--- a/cmd/declarative/test/test.go
+++ b/cmd/declarative/test/test.go
@@ -45,6 +45,8 @@ import (
 	stepbuilder "github.com/falcosecurity/event-generator/pkg/test/step/builder"
 	sysbuilder "github.com/falcosecurity/event-generator/pkg/test/step/syscall/builder"
 	"github.com/falcosecurity/event-generator/pkg/test/suite"
+	suiteloader "github.com/falcosecurity/event-generator/pkg/test/suite/loader"
+	suitesource "github.com/falcosecurity/event-generator/pkg/test/suite/source"
 	"github.com/falcosecurity/event-generator/pkg/test/tester"
 	"github.com/falcosecurity/event-generator/pkg/test/tester/reportencoder/jsonencoder"
 	"github.com/falcosecurity/event-generator/pkg/test/tester/reportencoder/textencoder"
@@ -312,7 +314,7 @@ func formatTestCase(testCase map[string]any) string {
 func loadTestSuites(logger logr.Logger, canLoadTestsWithNoRuleName bool, descriptionFilePaths,
 	descriptionDirPaths []string, description string) ([]*suite.Suite, error) {
 	descLoader := loader.New()
-	suiteLoader := suite.NewLoader(descLoader, canLoadTestsWithNoRuleName)
+	suiteLoader := suiteloader.New(descLoader, canLoadTestsWithNoRuleName)
 
 	// Load from the specified files or directories.
 	if len(descriptionFilePaths) > 0 || len(descriptionDirPaths) > 0 {
@@ -333,7 +335,7 @@ func loadTestSuites(logger logr.Logger, canLoadTestsWithNoRuleName bool, descrip
 
 	// Load from the provided description string.
 	if description != "" {
-		source := suite.NewSourceFromReader("<description flag>", strings.NewReader(description))
+		source := suitesource.New("<description flag>", strings.NewReader(description))
 		if err := suiteLoader.Load(source); err != nil {
 			return nil, fmt.Errorf("error loading from description flag: %w", err)
 		}
@@ -341,7 +343,7 @@ func loadTestSuites(logger logr.Logger, canLoadTestsWithNoRuleName bool, descrip
 	}
 
 	// Load from standard input.
-	source := suite.NewSourceFromReader("<stdin>", os.Stdin)
+	source := suitesource.New("<stdin>", os.Stdin)
 	if err := suiteLoader.Load(source); err != nil {
 		return nil, fmt.Errorf("error loading from stdin: %w", err)
 	}
@@ -350,7 +352,7 @@ func loadTestSuites(logger logr.Logger, canLoadTestsWithNoRuleName bool, descrip
 
 // loadTestsFromDescriptionDir loads tests, from YAML files inside the directory at the provided path, into the provided
 // suite loader.
-func loadTestsFromDescriptionDir(logger logr.Logger, suiteLoader *suite.Loader, descriptionDirPath string) error {
+func loadTestsFromDescriptionDir(logger logr.Logger, suiteLoader suite.Loader, descriptionDirPath string) error {
 	descriptionDirPath = filepath.Clean(descriptionDirPath)
 	dirEntries, err := os.ReadDir(descriptionDirPath)
 	if err != nil {
@@ -377,7 +379,7 @@ func loadTestsFromDescriptionDir(logger logr.Logger, suiteLoader *suite.Loader, 
 }
 
 // loadTestsFromDescriptionFile loads tests from the file at the provided path into the provided suite loader.
-func loadTestsFromDescriptionFile(logger logr.Logger, suiteLoader *suite.Loader, descriptionFilePath string) error {
+func loadTestsFromDescriptionFile(logger logr.Logger, suiteLoader suite.Loader, descriptionFilePath string) error {
 	descriptionFilePath = filepath.Clean(descriptionFilePath)
 	descriptionFile, err := os.Open(descriptionFilePath)
 	if err != nil {

--- a/pkg/test/suite/doc.go
+++ b/pkg/test/suite/doc.go
@@ -14,11 +14,10 @@
 // limitations under the License.
 
 // Package suite provides the definition of a test suite as well as a mechanism to load multiple test suites from
-// multiple sources.
+// multiple sources through the Loader interface.
 // A Suite is uniquely associated with a rule: each loaded test is associated with a specific Suite, depending on the
 // rule name it specifies on its description. If the user didn't specify any rule name in the test description, the test
 // is associated with the test suite corresponding to NoRuleNamePlaceholder.
 // The Loader can be used to load multiple test suites from multiple sources. Loader.Load accepts Source objects; a
-// Source is a named io.Reader, and can be created from files or from readers using the function NewSourceFromFile or
-// NewSourceFromReader, respectively.
+// Source is a named io.Reader.
 package suite

--- a/pkg/test/suite/loader/doc.go
+++ b/pkg/test/suite/loader/doc.go
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2025 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package loader provides the implementation of a suite.Loader.
+package loader

--- a/pkg/test/suite/loader/loader.go
+++ b/pkg/test/suite/loader/loader.go
@@ -1,0 +1,141 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2025 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package loader
+
+import (
+	"fmt"
+
+	testloader "github.com/falcosecurity/event-generator/pkg/test/loader"
+	"github.com/falcosecurity/event-generator/pkg/test/suite"
+)
+
+// loader is a suite.Loader implementation.
+type loader struct {
+	// descLoader is used to load a tests description from a single source.
+	descLoader *testloader.Loader
+	// canLoadTestsWithNoRuleName indicates if tests with absent or empty rule name are allowed to be loaded.
+	canLoadTestsWithNoRuleName bool
+	// loadedTestSuites is the list of all loaded test suites.
+	loadedTestSuites []*suite.Suite
+	// loadedTestSuiteIndexes takes note of the index, in loadedTestSuites, of each loaded test suite (used for fast
+	// lookup).
+	loadedTestSuiteIndexes map[string]int
+}
+
+// Verify that loader implements the suite.Loader interface.
+var _ suite.Loader = (*loader)(nil)
+
+// New creates a new test suite loader.
+func New(descLoader *testloader.Loader, canLoadTestsWithNoRuleName bool) suite.Loader {
+	l := &loader{
+		descLoader:                 descLoader,
+		canLoadTestsWithNoRuleName: canLoadTestsWithNoRuleName,
+		loadedTestSuiteIndexes:     make(map[string]int),
+	}
+	return l
+}
+
+func (l *loader) Load(source suite.Source) error {
+	// Load all tests from the provided list of sources and group them by rule name.
+	desc, err := l.descLoader.Load(source)
+	if err != nil {
+		return fmt.Errorf("error loading description: %w", err)
+	}
+
+	// Associate each loaded test to the proper test suite based on the specified rule name.
+	sourceName := source.Name()
+	for testIndex := range desc.Tests {
+		testDesc := &desc.Tests[testIndex]
+		ruleName := getRuleName(testDesc)
+		// Return an error if it is not allowed to load tests with absent/empty rule name and the test is not compliant
+		// with it.
+		if !l.canLoadTestsWithNoRuleName && ruleName == suite.NoRuleNamePlaceholder {
+			return &suite.NoRuleNameError{
+				TestName:        testDesc.Name,
+				TestSourceName:  sourceName,
+				TestSourceIndex: testDesc.SourceIndex,
+			}
+		}
+
+		var testSuite *suite.Suite
+		// Verify if we discovered a new test suite or not. If a new test suite is discovered, take note of its
+		// index in the returned slice to easily find the test suite a test belongs to.
+		testSuiteIndex, ok := l.loadedTestSuiteIndexes[ruleName]
+		if !ok {
+			// Found new test suite.
+			testSuite = &suite.Suite{RuleName: ruleName}
+			l.loadedTestSuites = append(l.loadedTestSuites, testSuite)
+			l.loadedTestSuiteIndexes[ruleName] = len(l.loadedTestSuites) - 1
+		} else {
+			// Test suite already exists.
+			testSuite = l.loadedTestSuites[testSuiteIndex]
+		}
+		testInfo := &suite.TestInfo{SourceName: sourceName, Test: testDesc}
+		testSuite.TestsInfo = append(testSuite.TestsInfo, testInfo)
+	}
+
+	// Validate each test suite.
+	for _, testSuite := range l.loadedTestSuites {
+		if err := validateTestNamesUniqueness(testSuite); err != nil {
+			return fmt.Errorf("error validating test suite %q's test names uniqueness: %w", testSuite.RuleName, err)
+		}
+	}
+
+	return nil
+}
+
+// getRuleName returns the name of the rule associated with the provided test description.
+func getRuleName(testDesc *testloader.Test) string {
+	if ruleName := testDesc.Rule; ruleName != nil && *ruleName != "" {
+		return *ruleName
+	}
+
+	return suite.NoRuleNamePlaceholder
+}
+
+// validateTestNamesUniqueness verifies that each suite's test has a unique name.
+func validateTestNamesUniqueness(testSuite *suite.Suite) error {
+	testsInfo := make(map[string]*suite.TestInfo, len(testSuite.TestsInfo))
+	for _, testInfo1 := range testSuite.TestsInfo {
+		name := testInfo1.Test.Name
+		if testInfo2, ok := testsInfo[name]; ok {
+			return fmt.Errorf("%s and %s have the same name %q", testInfoToString(testInfo1),
+				testInfoToString(testInfo2), name)
+		}
+		testsInfo[name] = testInfo1
+	}
+	return nil
+}
+
+// testInfoToString returns a stringified representation of the provided test info.
+func testInfoToString(testInfo *suite.TestInfo) string {
+	var testCase string
+	if len(testInfo.Test.OriginatingTestCase) > 0 {
+		testCase = ", testCase: \""
+		for k, v := range testInfo.Test.OriginatingTestCase {
+			testCase += fmt.Sprintf("%s=%v,", k, v)
+		}
+		testCase = testCase[:len(testCase)-1] + "\""
+	}
+	return fmt.Sprintf("test (source: %s, index: %d%s)", testInfo.SourceName, testInfo.Test.SourceIndex, testCase)
+}
+
+func (l *loader) Get() []*suite.Suite {
+	testSuites := l.loadedTestSuites
+	l.loadedTestSuites = nil
+	l.loadedTestSuiteIndexes = make(map[string]int)
+	return testSuites
+}

--- a/pkg/test/suite/reportencoder/jsonencoder/doc.go
+++ b/pkg/test/suite/reportencoder/jsonencoder/doc.go
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2025 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package jsonencoder provides an implementation of suite.ReportEncoder allowing to write a report to the underlying
+// destination using a JSON encoding.
+package jsonencoder

--- a/pkg/test/suite/reportencoder/jsonencoder/jsonencoder.go
+++ b/pkg/test/suite/reportencoder/jsonencoder/jsonencoder.go
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2025 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package jsonencoder
+
+import (
+	"encoding/json"
+	"io"
+
+	"github.com/falcosecurity/event-generator/pkg/test/suite"
+)
+
+// jsonEncoder is an implementation of suite.ReportEncoder allowing to write a report to the underlying destination
+// using a JSON encoding.
+type jsonEncoder struct {
+	writer io.Writer
+}
+
+// Verify that jsonEncoder implements suite.ReportEncoder interface.
+var _ suite.ReportEncoder = (*jsonEncoder)(nil)
+
+// New creates a new report JSON encoder.
+func New(w io.Writer) suite.ReportEncoder {
+	je := &jsonEncoder{writer: w}
+	return je
+}
+
+func (je *jsonEncoder) Encode(report *suite.Report) error {
+	encoder := json.NewEncoder(je.writer)
+	return encoder.Encode(report)
+}

--- a/pkg/test/suite/reportencoder/textencoder/doc.go
+++ b/pkg/test/suite/reportencoder/textencoder/doc.go
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2025 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package textencoder provides an implementation of suite.ReportEncoder allowing to write a report to the underlying
+// destination using a formatted text encoding.
+package textencoder

--- a/pkg/test/suite/reportencoder/textencoder/textencoder.go
+++ b/pkg/test/suite/reportencoder/textencoder/textencoder.go
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2025 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package textencoder
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/falcosecurity/event-generator/pkg/test/suite"
+	"github.com/falcosecurity/event-generator/pkg/test/tester"
+)
+
+// textEncoder is an implementation of suite.ReportEncoder allowing to write a report to the underlying destination
+// using a formatted text encoding.
+type textEncoder struct {
+	writer io.Writer
+}
+
+// Verify that textEncoder implements suite.ReportEncoder interface.
+var _ suite.ReportEncoder = (*textEncoder)(nil)
+
+// New creates a new report text-formatting encoder.
+func New(w io.Writer) suite.ReportEncoder {
+	te := &textEncoder{writer: w}
+	return te
+}
+
+func (te *textEncoder) Encode(report *suite.Report) error {
+	sb := &strings.Builder{}
+	writeFormatted(sb, "Test Suite: %s\n", report.TestSuiteName)
+	const padding = "   "
+
+	for _, testReport := range report.TestReports {
+		te.encodeTestReport(sb, testReport, padding)
+	}
+
+	_, err := io.WriteString(te.writer, sb.String())
+	return err
+}
+
+func (te *textEncoder) encodeTestReport(sb *strings.Builder, report *tester.Report, basePadding string) {
+	padding := basePadding
+	writeFormatted(sb, "%sTest: %s\n", padding, report.TestName)
+
+	padding += basePadding
+	if report.Empty() {
+		writeFormatted(sb, "%sFailed\n", padding)
+		return
+	}
+
+	writeFormatted(sb, "%sSuccessful matches: %d\n", padding, report.SuccessfulMatches)
+	writeFormatted(sb, "%sGenerated warnings: %d\n", padding, len(report.GeneratedWarnings))
+
+	padding += basePadding
+	for warningIndex := range report.GeneratedWarnings {
+		warning := &report.GeneratedWarnings[warningIndex]
+		writeFormatted(sb, "%sWarning %d\n", padding, warningIndex)
+		padding := padding + basePadding
+		for fieldWarningIndex := range warning.FieldWarnings {
+			fieldWarning := &warning.FieldWarnings[fieldWarningIndex]
+			writeFormatted(sb, "%sField: %s, Expected: %v, Got: %v\n", padding, fieldWarning.Field,
+				fieldWarning.Expected, fieldWarning.Got)
+		}
+	}
+
+	writeFormatted(sb, "\n")
+}
+
+// writeFormatted is a wrapper around fmt.Fprintf ignoring the returned values.
+func writeFormatted(w io.Writer, format string, a ...any) {
+	_, _ = fmt.Fprintf(w, format, a...)
+}

--- a/pkg/test/suite/reportencoder/yamlencoder/doc.go
+++ b/pkg/test/suite/reportencoder/yamlencoder/doc.go
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2025 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package yamlencoder provides an implementation of suite.ReportEncoder allowing to write a report to the underlying
+// destination using a YAML encoding.
+package yamlencoder

--- a/pkg/test/suite/reportencoder/yamlencoder/yamlencoder.go
+++ b/pkg/test/suite/reportencoder/yamlencoder/yamlencoder.go
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2025 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package yamlencoder
+
+import (
+	"io"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/falcosecurity/event-generator/pkg/test/suite"
+)
+
+// yamlEncoder is an implementation of suite.ReportEncoder allowing to write a report to the underlying destination
+// using a YAML encoding.
+type yamlEncoder struct {
+	writer io.Writer
+}
+
+// Verify that yamlEncoder implements suite.ReportEncoder interface.
+var _ suite.ReportEncoder = (*yamlEncoder)(nil)
+
+// New creates a new report JSON encoder.
+func New(w io.Writer) suite.ReportEncoder {
+	ye := &yamlEncoder{writer: w}
+	return ye
+}
+
+func (ye *yamlEncoder) Encode(report *suite.Report) error {
+	encoder := yaml.NewEncoder(ye.writer)
+	return encoder.Encode(report)
+}

--- a/pkg/test/suite/source/doc.go
+++ b/pkg/test/suite/source/doc.go
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2025 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package source provides the implementation of a suite.Source.
+package source

--- a/pkg/test/suite/source/source.go
+++ b/pkg/test/suite/source/source.go
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2025 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package source
+
+import (
+	"io"
+
+	"github.com/falcosecurity/event-generator/pkg/test/suite"
+)
+
+// source is a suite.Source implementation.
+type source struct {
+	name   string
+	reader io.Reader
+}
+
+// Verify that source implements the suite.Source interface.
+var _ suite.Source = (*source)(nil)
+
+func (s *source) Name() string {
+	return s.name
+}
+
+func (s *source) Read(p []byte) (int, error) {
+	return s.reader.Read(p)
+}
+
+// New creates a new suite.Source from the provided reader with the provided name.
+func New(name string, r io.Reader) suite.Source {
+	return &source{name: name, reader: r}
+}

--- a/pkg/test/suite/suite.go
+++ b/pkg/test/suite/suite.go
@@ -20,6 +20,7 @@ import (
 	"io"
 
 	"github.com/falcosecurity/event-generator/pkg/test/loader"
+	"github.com/falcosecurity/event-generator/pkg/test/tester"
 )
 
 // Source represents a test suite source. It is an io.Reader owning a name.
@@ -74,3 +75,15 @@ func (e *NoRuleNameError) Error() string {
 // NoRuleNamePlaceholder is the value given to the rule name field of a test not specifying any value for it.
 // Notice: whe choose the empty string as it is not a valid rule name.
 const NoRuleNamePlaceholder = ""
+
+// A Report contains test reports for all tests belonging to a test suite.
+type Report struct {
+	TestSuiteName string           `json:"suite" yaml:"suite"`
+	TestReports   []*tester.Report `json:"testReports" yaml:"testReports"`
+}
+
+// ReportEncoder allows to encode a report.
+type ReportEncoder interface {
+	// Encode encodes the provided report with a specific format and write it to the underlying destination.
+	Encode(report *Report) error
+}

--- a/pkg/test/suite/suite.go
+++ b/pkg/test/suite/suite.go
@@ -18,10 +18,16 @@ package suite
 import (
 	"fmt"
 	"io"
-	"os"
 
 	"github.com/falcosecurity/event-generator/pkg/test/loader"
 )
+
+// Source represents a test suite source. It is an io.Reader owning a name.
+type Source interface {
+	// Name returns the name associated to the source.
+	Name() string
+	io.Reader
+}
 
 // TestInfo wraps a test and provides additional information to it, such as the name of the source it belongs and its
 // index within the source.
@@ -32,18 +38,6 @@ type TestInfo struct {
 	Test *loader.Test
 }
 
-func (t *TestInfo) string() string {
-	var testCase string
-	if len(t.Test.OriginatingTestCase) > 0 {
-		testCase = ", testCase: \""
-		for k, v := range t.Test.OriginatingTestCase {
-			testCase += fmt.Sprintf("%s=%v,", k, v)
-		}
-		testCase = testCase[:len(testCase)-1] + "\""
-	}
-	return fmt.Sprintf("test (source: %s, index: %d%s)", t.SourceName, t.Test.SourceIndex, testCase)
-}
-
 // Suite represents a test suite for a specific rule.
 type Suite struct {
 	// RuleName is the name of the rule the tests are associated with.
@@ -52,73 +46,15 @@ type Suite struct {
 	TestsInfo []*TestInfo
 }
 
-// validateTestNamesUniqueness verifies that each suite's test has a unique name.
-func (s *Suite) validateTestNamesUniqueness() error {
-	testsInfo := make(map[string]*TestInfo, len(s.TestsInfo))
-	for _, testInfo1 := range s.TestsInfo {
-		name := testInfo1.Test.Name
-		if testInfo2, ok := testsInfo[name]; ok {
-			return fmt.Errorf("%s and %s have the same name %q", testInfo1.string(), testInfo2.string(), name)
-		}
-		testsInfo[name] = testInfo1
-	}
-	return nil
-}
-
-// Source is an io.Reader owning a name.
-type Source interface {
-	// Name returns the name associated to the source.
-	Name() string
-	io.Reader
-}
-
-// source is a Source implementation.
-type source struct {
-	name   string
-	reader io.Reader
-}
-
-// Verify that source implements the Source interface.
-var _ Source = (*source)(nil)
-
-func (s *source) Name() string {
-	return s.name
-}
-
-func (s *source) Read(p []byte) (int, error) {
-	return s.reader.Read(p)
-}
-
-// NewSourceFromFile creates a new Source from the provided file.
-func NewSourceFromFile(file *os.File) Source {
-	return &source{name: file.Name(), reader: file}
-}
-
-// NewSourceFromReader creates a new Source from the provided reader with the provided name.
-func NewSourceFromReader(name string, r io.Reader) Source {
-	return &source{name: name, reader: r}
-}
-
-// Loader loads test suites.
-type Loader struct {
-	// descLoader is used to load a tests description from a single source.
-	descLoader *loader.Loader
-	// canLoadTestsWithNoRuleName indicates if tests with absent or empty rule name are allowed to be loaded.
-	canLoadTestsWithNoRuleName bool
-	// loadedSuites is the list of all loaded test suites.
-	loadedSuites []*Suite
-	// loadedSuiteIndexes takes note of the index, in loadedSuites, of each loaded test suite (used for fast lookup).
-	loadedSuiteIndexes map[string]int
-}
-
-// NewLoader creates a new test suite loader.
-func NewLoader(descLoader *loader.Loader, canLoadTestsWithNoRuleName bool) *Loader {
-	l := &Loader{
-		descLoader:                 descLoader,
-		canLoadTestsWithNoRuleName: canLoadTestsWithNoRuleName,
-		loadedSuiteIndexes:         make(map[string]int),
-	}
-	return l
+// Loader allows to load multiple test suites from multiple sources.
+type Loader interface {
+	// Load loads the test suites from the provided source into the Loader instance. Load can be called multiple times
+	// with different sources. Call Get to obtain the list of all loaded test suites. If an error is generated, the
+	// Loader instance internal state remains undefined.
+	Load(source Source) error
+	// Get returns the list of all loaded test suites. After the call, the internal state of the loaded is re-set to a
+	// clean (initial) state.
+	Get() []*Suite
 }
 
 // NoRuleNameError represents an error occurring when is not allowed to load tests with absent or empty rule name and a
@@ -135,76 +71,6 @@ func (e *NoRuleNameError) Error() string {
 	return fmt.Sprintf("error loading test %q at index %d: absent or empty rule name", e.TestName, e.TestSourceIndex)
 }
 
-// Load loads the test suites from the provided source into the Loader instance. Load can be called multiple times with
-// different sources. Call Get to obtain the list of all loaded test suites. If an error is generated, the Loader
-// instance internal state remains undefined.
-func (l *Loader) Load(source Source) error {
-	// Load all tests from the provided list of sources and group them by rule name.
-	desc, err := l.descLoader.Load(source)
-	if err != nil {
-		return fmt.Errorf("error loading description: %w", err)
-	}
-
-	// Associate each loaded test to the proper test suite based on the specified rule name.
-	sourceName := source.Name()
-	for testIndex := range desc.Tests {
-		testDesc := &desc.Tests[testIndex]
-		ruleName := getRuleName(testDesc)
-		// Return an error if it is not allowed to load tests with absent/empty rule name and the test is not compliant
-		// with it.
-		if !l.canLoadTestsWithNoRuleName && ruleName == NoRuleNamePlaceholder {
-			return &NoRuleNameError{
-				TestName:        testDesc.Name,
-				TestSourceName:  sourceName,
-				TestSourceIndex: testDesc.SourceIndex,
-			}
-		}
-
-		var suite *Suite
-		// Verify if we discovered a new test suite or not. If a new test suite is discovered, take note of its
-		// index in the returned slice to easily find the test suite a test belongs to.
-		suiteIndex, ok := l.loadedSuiteIndexes[ruleName]
-		if !ok {
-			// Found new test suite.
-			suite = &Suite{RuleName: ruleName}
-			l.loadedSuites = append(l.loadedSuites, suite)
-			l.loadedSuiteIndexes[ruleName] = len(l.loadedSuites) - 1
-		} else {
-			// Test suite already exists.
-			suite = l.loadedSuites[suiteIndex]
-		}
-		testInfo := &TestInfo{SourceName: sourceName, Test: testDesc}
-		suite.TestsInfo = append(suite.TestsInfo, testInfo)
-	}
-
-	// Validate each test suite.
-	for _, suite := range l.loadedSuites {
-		if err := suite.validateTestNamesUniqueness(); err != nil {
-			return fmt.Errorf("error validating test suite %q's test names uniqueness: %w", suite.RuleName, err)
-		}
-	}
-
-	return nil
-}
-
 // NoRuleNamePlaceholder is the value given to the rule name field of a test not specifying any value for it.
 // Notice: whe choose the empty string as it is not a valid rule name.
 const NoRuleNamePlaceholder = ""
-
-// getRuleName returns the name of the rule associated with the provided test description.
-func getRuleName(testDesc *loader.Test) string {
-	if ruleName := testDesc.Rule; ruleName != nil && *ruleName != "" {
-		return *ruleName
-	}
-
-	return NoRuleNamePlaceholder
-}
-
-// Get returns the list of all loaded test suites. After the call, the internal state of the loaded is re-set to a clean
-// (initial) state.
-func (l *Loader) Get() []*Suite {
-	suites := l.loadedSuites
-	l.loadedSuites = nil
-	l.loadedSuiteIndexes = make(map[string]int)
-	return suites
-}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note: it's really useful for the changelog!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind documentation

> /kind tests

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area commands

/area pkg

> /area events

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR refactor the `suite` package by splitting the API definition from its implementation.  Specifically, `Loader` and `Source` implementation were moved to separate packages `suite/loader` and `suite/source`. Moreover, it adds the `suite.Report` and `suite.ReportEncoder` definitions, as well as the implementation of three test suite report encoders, namely `yamlencoder`, `jsonencoder` and `textencoder`. This preliminary work is needed in order to output as a whole test reports belonging to a single test suite (see #270).

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

