### PR TITLE
feat(decl/proc-chain): create proc exe dir hierarchy if not exist

### DIFF
--- a/pkg/process/process.go
+++ b/pkg/process/process.go
@@ -24,7 +24,9 @@ import (
 // Builder allows to build a new process.
 type Builder interface {
 	// SetSimExePath sets the "simulated" executable path. This sets the executable path accessible through
-	// `readlink -f /proc/<pid/exepath` for the started process. If unset or empty, it is randomly generated.
+	// `readlink -f /proc/<pid/exepath` for the started process. The underlying implementation ensures the existence of
+	// each segment of the provided path, by possibly creating some of them. Path segments contextually created are
+	// automatically removed after the process resources are released. If unset or empty, it is randomly generated.
 	SetSimExePath(simExePath string)
 	// SetName is the process name. If unset or empty, it defaults to filepath.Base(SimExePath).
 	SetName(name string)
@@ -44,8 +46,10 @@ type Builder interface {
 	// SetCapabilities sets the capabilities that must be set on the process executable file. The syntax follows the
 	// conventions specified by cap_from_text(3). If unset or empty, it defaults to 'all=iep'.
 	SetCapabilities(capabilities string)
-	// Build builds the process. After calling Build, the Builder process-related configuration is cleared and the
-	// Builder can be reused to build another process.
+	// Build builds the process, setting the logger managing its lifecycle and the command that it is going to run.
+	// The provided context can be used at any time to cancel the process execution after it is started.
+	// After calling Build, the Builder process-related configuration is cleared and the Builder can be reused to build
+	// another process.
 	Build(ctx context.Context, logger logr.Logger, command string) Process
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note: it's really useful for the changelog!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind documentation

> /kind tests

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area commands

/area pkg

> /area events

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR introduces the capability to automatically the directory hierarchy for a specified simulated executable path in process chain if it doesn't exist. The created hierarchy is automatically deleted upon process resources release.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

