### PR TITLE
fix(suite/step/syscalls): align `read` and `write` step args after run

### DIFF
--- a/pkg/test/step/syscall/read/read.go
+++ b/pkg/test/step/syscall/read/read.go
@@ -71,6 +71,8 @@ func (r *readSyscall) Run(_ context.Context) error {
 		return err
 	}
 
+	r.args.Len = length
+	r.args.Buffer = buffer
 	r.Ret = readBytes
 	return nil
 }

--- a/pkg/test/step/syscall/write/write.go
+++ b/pkg/test/step/syscall/write/write.go
@@ -70,6 +70,7 @@ func (w *writeSyscall) Run(_ context.Context) error {
 		return err
 	}
 
+	w.args.Len = length
 	w.Ret = writtenBytes
 	return nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note: it's really useful for the changelog!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind documentation

> /kind tests

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area commands

/area pkg

> /area events

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR updates, upon successful execution, `read` and `write` syscall steps buffers and lengths arguments to their new value. This is especially important when buffers are created on the fly with the specified length, or when lengths default to the buffers length. This is required in order to enable subsequent steps to correctly see the updated values.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

