### PR TITLE
feat(suite/step/syscalls): allow to omit `read` `buffer` or `len` arg

### DIFF
--- a/pkg/test/step/syscall/read/read.go
+++ b/pkg/test/step/syscall/read/read.go
@@ -42,11 +42,15 @@ type readSyscall struct {
 // New creates a new read system call test step.
 func New(name string, rawArgs map[string]any, fieldBindings []*step.FieldBinding) (syscall.Syscall, error) {
 	r := &readSyscall{}
+	// r.args.Buffer defaults to a buffer of length r.args.Len at run time, if unbound.
+	// r.args.Len defaults to the buffer length at run time, if unbound.
 	argsContainer := reflect.ValueOf(&r.args).Elem()
 	bindOnlyArgsContainer := reflect.ValueOf(&r.bindOnlyArgs).Elem()
 	retValContainer := reflect.ValueOf(r).Elem()
+	defaultedArgs := []string{"buffer", "len"}
 	var err error
-	r.Syscall, err = base.New(name, rawArgs, fieldBindings, argsContainer, bindOnlyArgsContainer, retValContainer)
+	r.Syscall, err = base.New(name, rawArgs, fieldBindings, argsContainer, bindOnlyArgsContainer, retValContainer,
+		base.WithDefaultedArgs(defaultedArgs), base.WithOneRequiredArg(defaultedArgs))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note: it's really useful for the changelog!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind documentation

> /kind tests

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area commands

/area pkg

> /area events

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR allows the user to omit `buffer` or `len` arguments but not both. The omitted argument is defaulted using the other argument configuration.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

