### PR TITLE
chore(chart): add source chart

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 <!--  Thanks for sending a pull request!  Here are some tips for you:
 
-1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file.
+1. If this is your first time, please read our [CONTRIBUTING.md](../CONTRIBUTING.md).
 2. Please label this pull request according to what type of issue you are addressing.
 3. Please add a release note: it's really useful for the changelog!
 4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
@@ -34,6 +34,8 @@ Please remove the leading whitespace before the `/kind <>` you uncommented.
 
 > /area events
 
+> /area chart
+
 > /area automation
 
 <!--
@@ -53,4 +55,3 @@ If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issu
 Fixes #
 
 **Special notes for your reviewer**:
-

--- a/.github/workflows/helm-check.yaml
+++ b/.github/workflows/helm-check.yaml
@@ -1,0 +1,61 @@
+name: Helm Chart Check
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "chart/event-generator/**"
+      - ".github/workflows/helm-check.yaml"
+      - "ct.yaml"
+      - "Makefile"
+  pull_request:
+    paths:
+      - "chart/event-generator/**"
+      - ".github/workflows/helm-check.yaml"
+      - "ct.yaml"
+      - "Makefile"
+
+jobs:
+  helm-check:
+    name: Verify Helm Chart
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          persist-credentials: false
+
+      - name: Set up Helm
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
+        with:
+          version: "4.1.1"
+
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: "go.mod"
+          check-latest: true
+
+      - name: Install helm-docs
+        run: go install github.com/norwoodj/helm-docs/cmd/helm-docs@v1.11.0
+
+      - name: Verify chart README
+        run: HELM_DOCS="$(go env GOPATH)/bin/helm-docs" make chart-docs-check
+
+      - name: Setup Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.x"
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@6ec842c01de15ebb84c8627d2744a0c2f2755c9f # v2.8.0
+
+      - name: Run chart-testing lint
+        run: ct lint --config ct.yaml --charts chart/event-generator
+
+      - name: Create KIND Cluster
+        uses: helm/kind-action@ef37e7f390d99f746eb8b610417061a60e82a6cc # v1.14.0
+
+      - name: Run chart-testing install
+        run: ct install --exclude-deprecated --config ct.yaml --charts chart/event-generator

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-event-generator
-evtgen-docgen
+/event-generator
+/evtgen-docgen
 dist/
 events/k8saudit/yaml/bundle.go

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,21 @@
+# Contributing
+
+For general Falco contribution guidelines, including DCO sign-off, see the organization-wide [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md).
+
+## Helm Chart Contributions
+
+The event-generator chart source lives in this repository under [`chart/event-generator`](chart/event-generator). This repository is the source of truth for chart changes, chart version bumps, changelog entries, and generated chart docs.
+
+Published Falco charts live in [`falcosecurity/charts`](https://github.com/falcosecurity/charts). After chart changes are merged here, Falco infrastructure opens or updates the matching chart release PR in `falcosecurity/charts`.
+
+PRs that change chart templates, values, release metadata, or the application version rendered by the chart must update [`chart/event-generator/Chart.yaml`](chart/event-generator/Chart.yaml) and [`chart/event-generator/CHANGELOG.md`](chart/event-generator/CHANGELOG.md) in this repository.
+
+Use SemVer for the chart `version`: major for breaking changes to values, rendered resources, or upgrade behavior; minor for backward-compatible chart features; patch for backward-compatible fixes or metadata changes. Set `appVersion` to the event-generator version rendered by the chart.
+
+If chart values or chart documentation change, update [`chart/event-generator/README.gotmpl`](chart/event-generator/README.gotmpl) and regenerate [`chart/event-generator/README.md`](chart/event-generator/README.md).
+
+Before opening a chart PR, run:
+
+```bash
+make chart-check
+```

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,8 @@ SHELL=/bin/bash -o pipefail
 
 GO ?= go
 DOCKER ?= docker
+HELM ?= helm
+HELM_DOCS ?= helm-docs
 
 COMMIT_NO := $(shell git rev-parse HEAD 2> /dev/null || true)
 GIT_COMMIT := $(if $(shell git status --porcelain --untracked-files=no),${COMMIT_NO}-dirty,${COMMIT_NO})
@@ -39,6 +41,7 @@ TEST_FLAGS ?= -v -race
 main ?= .
 output ?= event-generator
 docgen ?= evtgen-docgen
+chart ?= chart/event-generator
 
 .PHONY: build
 build: prepare ${output}
@@ -73,6 +76,25 @@ docs: ${docgen}
 	$(RM) -R docs/*
 	@mkdir -p docs
 	${PWD}/${docgen}
+
+.PHONY: chart-lint
+chart-lint:
+	$(HELM) lint ${chart}
+
+.PHONY: chart-template
+chart-template:
+	$(HELM) template event-generator ${chart} --namespace event-generator
+
+.PHONY: chart-docs
+chart-docs:
+	$(HELM_DOCS) -c ./${chart} -t ./README.gotmpl -o ./README.md
+
+.PHONY: chart-docs-check
+chart-docs-check: chart-docs
+	git diff --exit-code -- ${chart}/README.md
+
+.PHONY: chart-check
+chart-check: chart-lint chart-template chart-docs-check
 
 .PHONY: image
 image:

--- a/chart/event-generator/.helmignore
+++ b/chart/event-generator/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/chart/event-generator/CHANGELOG.md
+++ b/chart/event-generator/CHANGELOG.md
@@ -1,0 +1,49 @@
+
+# Change Log
+
+This file documents all notable changes to `event-generator` Helm Chart. The release
+numbering uses [semantic versioning](http://semver.org).
+
+## v0.3.4
+
+* Pass `--all` flag to event-generator binary to allow disabled rules to run, e.g. the k8saudit ruleset.
+
+## v0.3.3
+
+* Update README.md.
+
+## v0.3.2
+
+* no change to the chart itself. Updated README.md and makefile.
+
+## v0.3.1
+
+* noop change just to test the ci
+
+## v0.3.0
+
+## Major Changes
+
+* Support configuration of revisionHistoryLimit of the deployment
+
+## v0.2.0
+
+## Major Changes
+
+* Changing the grpc socket path from `unix:///var/run/falco/falco.soc` to `unix:///run/falco/falco.sock`. Please note that this change is potentially a breaking change if deploying the event generator alongside Falco < 0.33.0.
+
+### Minor Changes
+
+* Bump event-generator to 0.10.0
+
+## v0.1.1
+
+### Minor Changes
+
+* Adding `-sleep` flag to the `pod-template.yaml` 
+
+## v0.1.0
+
+### Major Changes
+
+* Initial release of event-generator Helm Chart

--- a/chart/event-generator/Chart.yaml
+++ b/chart/event-generator/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: event-generator
+description: A Helm chart used to deploy the event-generator in Kubernetes cluster.
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.3.4
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "0.10.0"

--- a/chart/event-generator/README.gotmpl
+++ b/chart/event-generator/README.gotmpl
@@ -1,0 +1,123 @@
+# Event-generator
+
+[event-generator](https://github.com/falcosecurity/event-generator) is a tool designed to generate events for both syscalls and k8s audit. The tool can be used to check if Falco is working properly. It does so by performing a variety of suspects actions which trigger security events. The event-event generator implements a [minimalistic framework](https://github.com/falcosecurity/event-generator/tree/master/events) which makes easy to implement new actions.
+
+## Introduction
+
+This chart helps to deploy the event-generator in a kubernetes cluster in order to test an already deployed Falco instance.
+
+## Adding `falcosecurity` repository
+
+Before installing the chart, add the `falcosecurity` charts repository:
+
+```bash
+helm repo add falcosecurity https://falcosecurity.github.io/charts
+helm repo update
+```
+
+## Installing the Chart
+
+To install the chart with default values and release name `event-generator` run:
+
+```bash
+helm install event-generator falcosecurity/event-generator
+```
+
+After a few seconds, event-generator should be running in the `default` namespace.
+
+In order to install the event-generator in a custom namespace run:
+
+```bash
+# change the name of the namespace to fit your requirements.
+kubectl create ns "ns-event-generator"
+helm install event-generator falcosecurity/event-generator --namespace "ns-event-generator"
+```
+When the event-generator is installed using the default values in `values.yaml` file it is deployed using a k8s job, running the `run` command and, generates activity only for the k8s audit.
+For more info check the next section.
+
+> **Tip**: List all releases using `helm list`, a release is a name used to track a specific deployment
+
+### Commands, actions and options
+
+The event-generator tool accepts two commands: `run` and `test`. The first just generates activity, the later one, which is more sophisticated, also checks that for each generated activity Falco triggers the expected rule. Both of them accepts an argument that determines the actions to be performed:
+
+```bash
+event-generator run/test [regexp]
+```
+
+Without arguments, all actions are performed; otherwise, only those actions matching the given regular expression. If we want to `test` just the actions related to k8s the following command does the trick:
+
+```bash
+event-generator test ^k8saudit
+```
+The list of the supported actions can be found [here](https://github.com/falcosecurity/event-generator#list-actions)
+
+Before diving in how this helm chart deploys and manages instances of the event-generator in kubernetes there are two more options that we need to talk about:
++ `--loop` to run actions in a loop
++ `--sleep` to set the length of time to wait before running an action (default to 1s)
+
+### Deployment modes in k8s
+Based on commands, actions and options configured the event-generator could be deployed as a k8s `job` or `deployment`. If the `config.loop` value is set a `deployment` is used since it is long running process, otherwise a `job`.
+A configuration like the one below, set in the `values.yaml` file, will deploy the even-generator using a `deployment` with the `run` command passed to it and will will generate activity only for the syscalls:
+```yaml
+config:
+  # -- The event-generator accepts two commands (run, test):
+  # run: runs actions.
+  # test: runs and tests actions.
+  # For more info see: https://github.com/falcosecurity/event-generator
+  command: run
+  # -- Regular expression used to select the actions to be run.
+  actions: "^syscall"
+  # -- Runs in a loop the actions.
+  # If set to "true" the event-generator is deployed using a k8s deployment otherwise a k8s job.
+  loop: true
+  # -- The length of time to wait before running an action. Non-zero values should contain
+  # a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means no sleep. (default 100ms)
+  sleep: ""
+
+  grpc:
+    # -- Set it to true if you are deploying in "test" mode.
+    enabled: false
+    # -- Path to the Falco grpc socket.
+    bindAddress: "unix:///var/run/falco/falco.sock"
+```
+
+The following configuration will use a k8s `job` since we want to perform the k8s activity once and check that Falco reacts properly to those actions:
+```yaml
+config:
+  # -- The event-generator accepts two commands (run, test):
+  # run: runs actions.
+  # test: runs and tests actions.
+  # For more info see: https://github.com/falcosecurity/event-generator
+  command: test
+  # -- Regular expression used to select the actions to be run.
+  actions: "^k8saudit"
+  # -- Runs in a loop the actions.
+  # If set to "true" the event-generator is deployed using a k8s deployment otherwise a k8s job.
+  loop: false
+  # -- The length of time to wait before running an action. Non-zero values should contain
+  # a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means no sleep. (default 100ms)
+  sleep: ""
+
+  grpc:
+    # -- Set it to true if you are deploying in "test" mode.
+    enabled: true
+    # -- Path to the Falco grpc socket.
+    bindAddress: "unix:///var/run/falco/falco.sock"
+  ```
+
+Note that **grpc.enabled is set to true when running with the test command. Be sure that Falco exposes the grpc socket and emits output to it**.
+
+
+## Uninstalling the Chart
+To uninstall the `event-generator` release:
+```bash
+helm uninstall event-generator
+```
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+The following table lists the main configurable parameters of the {{ template "chart.name" . }} chart v{{ template "chart.version" . }} and their default values. See `values.yaml` for full list.
+
+{{ template "chart.valuesSection" . }}

--- a/chart/event-generator/README.md
+++ b/chart/event-generator/README.md
@@ -1,0 +1,145 @@
+# Event-generator
+
+[event-generator](https://github.com/falcosecurity/event-generator) is a tool designed to generate events for both syscalls and k8s audit. The tool can be used to check if Falco is working properly. It does so by performing a variety of suspects actions which trigger security events. The event-event generator implements a [minimalistic framework](https://github.com/falcosecurity/event-generator/tree/master/events) which makes easy to implement new actions.
+
+## Introduction
+
+This chart helps to deploy the event-generator in a kubernetes cluster in order to test an already deployed Falco instance.
+
+## Adding `falcosecurity` repository
+
+Before installing the chart, add the `falcosecurity` charts repository:
+
+```bash
+helm repo add falcosecurity https://falcosecurity.github.io/charts
+helm repo update
+```
+
+## Installing the Chart
+
+To install the chart with default values and release name `event-generator` run:
+
+```bash
+helm install event-generator falcosecurity/event-generator
+```
+
+After a few seconds, event-generator should be running in the `default` namespace.
+
+In order to install the event-generator in a custom namespace run:
+
+```bash
+# change the name of the namespace to fit your requirements.
+kubectl create ns "ns-event-generator"
+helm install event-generator falcosecurity/event-generator --namespace "ns-event-generator"
+```
+When the event-generator is installed using the default values in `values.yaml` file it is deployed using a k8s job, running the `run` command and, generates activity only for the k8s audit.
+For more info check the next section.
+
+> **Tip**: List all releases using `helm list`, a release is a name used to track a specific deployment
+
+### Commands, actions and options
+
+The event-generator tool accepts two commands: `run` and `test`. The first just generates activity, the later one, which is more sophisticated, also checks that for each generated activity Falco triggers the expected rule. Both of them accepts an argument that determines the actions to be performed:
+
+```bash
+event-generator run/test [regexp]
+```
+
+Without arguments, all actions are performed; otherwise, only those actions matching the given regular expression. If we want to `test` just the actions related to k8s the following command does the trick:
+
+```bash
+event-generator test ^k8saudit
+```
+The list of the supported actions can be found [here](https://github.com/falcosecurity/event-generator#list-actions)
+
+Before diving in how this helm chart deploys and manages instances of the event-generator in kubernetes there are two more options that we need to talk about:
++ `--loop` to run actions in a loop
++ `--sleep` to set the length of time to wait before running an action (default to 1s)
+
+### Deployment modes in k8s
+Based on commands, actions and options configured the event-generator could be deployed as a k8s `job` or `deployment`. If the `config.loop` value is set a `deployment` is used since it is long running process, otherwise a `job`.
+A configuration like the one below, set in the `values.yaml` file, will deploy the even-generator using a `deployment` with the `run` command passed to it and will will generate activity only for the syscalls:
+```yaml
+config:
+  # -- The event-generator accepts two commands (run, test):
+  # run: runs actions.
+  # test: runs and tests actions.
+  # For more info see: https://github.com/falcosecurity/event-generator
+  command: run
+  # -- Regular expression used to select the actions to be run.
+  actions: "^syscall"
+  # -- Runs in a loop the actions.
+  # If set to "true" the event-generator is deployed using a k8s deployment otherwise a k8s job.
+  loop: true
+  # -- The length of time to wait before running an action. Non-zero values should contain
+  # a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means no sleep. (default 100ms)
+  sleep: ""
+
+  grpc:
+    # -- Set it to true if you are deploying in "test" mode.
+    enabled: false
+    # -- Path to the Falco grpc socket.
+    bindAddress: "unix:///var/run/falco/falco.sock"
+```
+
+The following configuration will use a k8s `job` since we want to perform the k8s activity once and check that Falco reacts properly to those actions:
+```yaml
+config:
+  # -- The event-generator accepts two commands (run, test):
+  # run: runs actions.
+  # test: runs and tests actions.
+  # For more info see: https://github.com/falcosecurity/event-generator
+  command: test
+  # -- Regular expression used to select the actions to be run.
+  actions: "^k8saudit"
+  # -- Runs in a loop the actions.
+  # If set to "true" the event-generator is deployed using a k8s deployment otherwise a k8s job.
+  loop: false
+  # -- The length of time to wait before running an action. Non-zero values should contain
+  # a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means no sleep. (default 100ms)
+  sleep: ""
+
+  grpc:
+    # -- Set it to true if you are deploying in "test" mode.
+    enabled: true
+    # -- Path to the Falco grpc socket.
+    bindAddress: "unix:///var/run/falco/falco.sock"
+  ```
+
+Note that **grpc.enabled is set to true when running with the test command. Be sure that Falco exposes the grpc socket and emits output to it**.
+
+## Uninstalling the Chart
+To uninstall the `event-generator` release:
+```bash
+helm uninstall event-generator
+```
+The command removes all the Kubernetes components associated with the chart and deletes the release.
+
+## Configuration
+
+The following table lists the main configurable parameters of the event-generator chart v0.3.4 and their default values. See `values.yaml` for full list.
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` | Affinity, like the nodeSelector but with more expressive syntax. |
+| config.actions | string | `"^syscall"` | Regular expression used to select the actions to be run. |
+| config.command | string | `"run"` | The event-generator accepts two commands (run, test): run: runs actions. test: runs and tests actions. For more info see: https://github.com/falcosecurity/event-generator. |
+| config.grpc.bindAddress | string | `"unix:///run/falco/falco.sock"` | Path to the Falco grpc socket. |
+| config.grpc.enabled | bool | `false` | Set it to true if you are deploying in "test" mode. |
+| config.loop | bool | `true` | Runs in a loop the actions. If set to "true" the event-generator is deployed using a k8s deployment otherwise a k8s job. |
+| config.sleep | string | `""` | The length of time to wait before running an action. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means no sleep. (default 100ms) |
+| fullnameOverride | string | `""` | Used to override the chart full name. |
+| image | object | `{"pullPolicy":"IfNotPresent","repository":"falcosecurity/event-generator","tag":"latest"}` | Number of old history to retain to allow rollback (If not set, default Kubernetes value is set to 10) revisionHistoryLimit: 1 |
+| image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the event-generator image |
+| image.repository | string | `"falcosecurity/event-generator"` | Repository from where the image is pulled. |
+| image.tag | string | `"latest"` | Images' tag to select a development/custom version of event-generator instead of a release. Overrides the image tag whose default is the chart appVersion. |
+| imagePullSecrets | list | `[]` | Secrets used to pull the image from a private repository. |
+| nameOverride | string | `""` | Used to override the chart name. |
+| nodeSelector | object | `{}` | Selectors to choose a given node where to run the pods. |
+| podAnnotations | object | `{}` | Annotations to be added to the pod. |
+| podSecurityContext | object | `{}` | Security context for the pod. |
+| replicasCount | int | `1` | Number of replicas of the event-generator (meaningful when installed as a deployment). |
+| securityContext | object | `{}` | Security context for the containers. |
+| tolerations | list | `[]` | Tolerations to allow the pods to be scheduled on nodes whose taints the pod tolerates. |

--- a/chart/event-generator/templates/_helpers.tpl
+++ b/chart/event-generator/templates/_helpers.tpl
@@ -1,0 +1,69 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "event-generator.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "event-generator.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "event-generator.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "event-generator.labels" -}}
+helm.sh/chart: {{ include "event-generator.chart" . }}
+{{ include "event-generator.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "event-generator.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "event-generator.name" . | quote }}
+app.kubernetes.io/instance: {{ .Release.Name | quote }}
+app.kubernetes.io/part-of: {{ include "event-generator.name" . | quote }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "event-generator.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "event-generator.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{- define "grpc.unixSocketDir" -}}
+{{- if and .Values.config.grpc.enabled .Values.config.grpc.bindAddress (hasPrefix "unix://" .Values.config.grpc.bindAddress) -}}
+{{- .Values.config.grpc.bindAddress | trimPrefix "unix://" | dir -}}
+{{- end -}}
+{{- end -}}

--- a/chart/event-generator/templates/deployment.yaml
+++ b/chart/event-generator/templates/deployment.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.config.loop -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "event-generator.fullname" . }}
+  labels:
+    {{- include "event-generator.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicasCount }}
+  {{- if .Values.revisionHistoryLimit }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "event-generator.selectorLabels" . | nindent 6 }}
+  template:
+    {{- include "event-generator.podTemplate" . | nindent 4 }}
+{{- end -}}

--- a/chart/event-generator/templates/job.yaml
+++ b/chart/event-generator/templates/job.yaml
@@ -1,0 +1,12 @@
+{{- if not .Values.config.loop -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "event-generator.fullname" . }}
+  labels:
+    {{- include "event-generator.labels" . | nindent 4 }}
+spec:
+  backoffLimit: 1
+  template:
+    {{- include "event-generator.podTemplate" . | nindent 4 }}
+{{- end -}}

--- a/chart/event-generator/templates/pod-template.tpl
+++ b/chart/event-generator/templates/pod-template.tpl
@@ -1,0 +1,70 @@
+{{- define "event-generator.podTemplate" -}}
+metadata:
+  {{- with .Values.podAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "event-generator.selectorLabels" . | nindent 4 }}
+spec:
+  {{- with .Values.imagePullSecrets }}
+  imagePullSecrets:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  serviceAccountName: {{ include "event-generator.fullname" . }}
+  securityContext:
+    {{- toYaml .Values.podSecurityContext | nindent 4 }}
+  containers:
+    - name: {{ .Chart.Name }}
+      securityContext:
+        {{- toYaml .Values.securityContext | nindent 8 }}
+      image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+      imagePullPolicy: {{ .Values.image.pullPolicy }}
+      command: 
+        - /bin/event-generator 
+        - {{ .Values.config.command }}
+        - --all
+        {{- if .Values.config.actions }}
+        - {{ .Values.config.actions }}
+        {{- end }}
+        {{- if .Values.config.loop }}
+        - --loop
+        {{- end }}
+        {{- if .Values.config.sleep }}
+        - --sleep={{- .Values.config.sleep }}
+        {{- end }}
+        {{- if .Values.config.grpc.enabled }}
+        - --grpc-unix-socket={{- .Values.config.grpc.bindAddress }}
+        {{- end }}
+      env:
+      - name: FALCO_EVENT_GENERATOR_NAMESPACE
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.namespace
+      {{- if .Values.config.grpc.enabled }}
+      volumeMounts:
+      - mountPath: {{ include "grpc.unixSocketDir" . }} 
+        name: unix-socket-dir
+      {{- end }}
+  {{- if .Values.config.grpc.enabled }}
+  volumes:
+  - hostPath:
+      path: {{ include "grpc.unixSocketDir" . }} 
+    name: unix-socket-dir       
+  {{- end }}          
+  {{- with .Values.nodeSelector }}
+  nodeSelector:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.affinity }}
+  affinity:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.tolerations }}
+  tolerations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- if not .Values.config.loop }}
+  restartPolicy: Never
+  {{- end }}
+{{- end -}}

--- a/chart/event-generator/templates/rbac.yaml
+++ b/chart/event-generator/templates/rbac.yaml
@@ -1,0 +1,76 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "event-generator.fullname" . }}
+  labels:
+    {{- include "event-generator.labels" . | nindent 4 }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "event-generator.fullname" . }}
+  labels:
+    {{- include "event-generator.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - services
+  - serviceaccounts
+  - pods
+  verbs:
+  - list
+  - get
+  - create
+  - delete
+- apiGroups:
+  - apps
+  - extensions
+  resources:
+  - deployments
+  verbs:
+  - list
+  - get
+  - create
+  - delete
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  - rolebindings
+  verbs:
+  - get
+  - list
+  - create
+  - delete
+# These are only so the event generator can create roles that have these properties.
+# It will result in a falco alert for the rules "ClusterRole With Wildcard Created", "ClusterRole With Pod Exec Created"
+- apiGroups:
+  - ""
+  resources:
+  - pods/exec
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
+  - '*'
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "event-generator.fullname" . }}
+  labels:
+    {{- include "event-generator.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "event-generator.fullname" . }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ include "event-generator.fullname" . }}
+  apiGroup: rbac.authorization.k8s.io
+---

--- a/chart/event-generator/values.yaml
+++ b/chart/event-generator/values.yaml
@@ -1,0 +1,71 @@
+# Default values for event-generator.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# -- Number of replicas of the event-generator (meaningful when installed as a deployment).
+replicasCount: 1
+
+# -- Number of old history to retain to allow rollback (If not set, default Kubernetes value is set to 10)
+# revisionHistoryLimit: 1
+
+image:
+  # -- Repository from where the image is pulled.
+  repository: falcosecurity/event-generator
+  # -- Pull policy for the event-generator image
+  pullPolicy: IfNotPresent
+  # -- Images' tag to select a development/custom version of event-generator instead of a release.
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: "latest"
+
+# -- Secrets used to pull the image from a private repository.
+imagePullSecrets: []
+# -- Used to override the chart name.
+nameOverride: ""
+# -- Used to override the chart full name.
+fullnameOverride: ""
+
+# -- Annotations to be added to the pod.
+podAnnotations: {}
+
+# -- Security context for the pod.
+podSecurityContext: {}
+  # fsGroup: 2000
+
+# -- Security context for the containers.
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+# -- Selectors to choose a given node where to run the pods.
+nodeSelector: {}
+
+# -- Tolerations to allow the pods to be scheduled on nodes whose taints the pod tolerates.
+tolerations: []
+
+# -- Affinity, like the nodeSelector but with more expressive syntax.
+affinity: {}
+
+config:
+  # -- The event-generator accepts two commands (run, test):
+  # run: runs actions.
+  # test: runs and tests actions.
+  # For more info see: https://github.com/falcosecurity/event-generator.
+  command: run
+  # -- Regular expression used to select the actions to be run.
+  actions: "^syscall"
+  # -- Runs in a loop the actions.
+  # If set to "true" the event-generator is deployed using a k8s deployment otherwise a k8s job.
+  loop: true
+  # -- The length of time to wait before running an action. Non-zero values should contain
+  # a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means no sleep. (default 100ms)
+  sleep: ""
+
+  grpc:
+    # -- Set it to true if you are deploying in "test" mode.
+    enabled: false
+    # -- Path to the Falco grpc socket.
+    bindAddress: "unix:///run/falco/falco.sock"

--- a/ct.yaml
+++ b/ct.yaml
@@ -1,0 +1,8 @@
+remote: origin
+validate-maintainers: false
+target-branch: main
+chart-repos:
+  - falcosecurity=https://falcosecurity.github.io/charts
+helm-extra-args: --timeout 800s
+chart-dirs:
+  - chart


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines in the [CONTRIBUTING.md](https://github.com/falcosecurity/.github/blob/main/CONTRIBUTING.md) file.
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note: it's really useful for the changelog!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

/kind cleanup

> /kind documentation

/kind tests

> /kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area commands

> /area pkg

> /area events

/area chart

/area automation

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

Adds the `event-generator` Helm chart under `chart/event-generator`, copied from `falcosecurity/charts` without chart content changes.

This makes this repository the source of truth for the chart. The chart can then be synced automatically to `falcosecurity/charts` by the shared `sync-charts` automation.

The PR also adds chart verification targets and a Helm chart CI workflow covering:

- README generation check with `helm-docs`
- chart-testing lint
- chart-testing install on Kind

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

The chart content is intentionally identical to the current `charts/event-generator` chart. Future chart changes should happen here and be synced to `falcosecurity/charts`.

