### PR TITLE
chore(chart)!: sync chart with `0.13.0`

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,11 +231,11 @@ The above command loops forever, creating resources in the `falco-eg-sandbox` na
 
 Since `v0.4.0`, this tool introduces a convenient integration test suite for Falco rules. The `event-generator test` command can run actions and test them against a running Falco instance.
 
-> This feature requires Falco 0.24.0 or newer. Before using the command below, you need [Falco installed](https://falco.org/docs/installation/) and running with the [gRPC Output](https://falco.org/docs/grpc/) enabled.
+> Before using the command below, you need [Falco installed](https://falco.org/docs/installation/) and running with its HTTP Output enabled and pointing at the event-generator's HTTP server.
 
 #### Test locally (`syscall` only)
 
-Run the following command to test `syscall` actions on a local Falco instance (connects via Unix socket to `/run/falco/falco.sock` by default):
+Run the following command to test `syscall` actions on a local Falco instance. The `test` command hosts an HTTP server at `localhost:8080` by default, which Falco posts alerts to:
 
 ```shell
 sudo ./event-generator test syscall
@@ -272,8 +272,6 @@ Note that to test `k8saudit` events, you need _Kubernetes Audit Log_ functionali
 
 Since `v0.5.0`, the `event-generator` can also be used for benchmarking a running instance of Falco. The command `event-generator bench` generates a high number of Event Per Second (EPS) to show you events throughput allowed by your Falco installation.
 
-Be aware that before Falco 0.37 a rate-limiter for notifications that affects the gRPC Outputs APIs was present. You probably need to increase the `outputs.rate` and `outputs.max_burst` values [within the Falco configuration](https://github.com/falcosecurity/falco/blob/e2bf87d207a32401da271835e15dadf957f68e8c/falco.yaml#L90-L104), otherwise EPS will be rate-limited by the throttling mechanism. 
-
 ### Run a benchmark
 
 Before starting a benchmark, the most important thing to understand is that the `--sleep` option controls the number of EPS (default to `250ms`): reducing this value will increase the EPS. Furthermore, if the `--loop` option is set, the sleeping duration is automatically halved on each round. The `--pid` option can be used to monitor the Falco process. 
@@ -284,7 +282,7 @@ Please, keep in mind that not all actions can be used for benchmarking since som
 
 **Benchmark example**
 
-A common way for benchmarking a local Falco instance is by running the following command (that connects via Unix socket to `/run/falco/falco.sock` by default):
+A common way for benchmarking a local Falco instance is by running the following command (`bench` hosts an HTTP server at `localhost:8080` by default, which Falco posts alerts to):
 
 ```shell
 sudo event-generator bench "ChangeThreadNamespace|ReadSensitiveFileUntrusted" --all --loop --sleep 10ms --pid $(pidof -s falco)

--- a/chart/event-generator/CHANGELOG.md
+++ b/chart/event-generator/CHANGELOG.md
@@ -4,6 +4,14 @@
 This file documents all notable changes to `event-generator` Helm Chart. The release
 numbering uses [semantic versioning](http://semver.org).
 
+## v0.4.0
+
+### Major Changes
+
+* Bump `event-generator` to `0.13.0`.
+* Replace the legacy gRPC alert retriever with the HTTP one introduced in `event-generator` `0.13.0`. The `config.grpc` section has been removed and replaced by `config.http`, exposing `address`, `securityMode` (`insecure`/`tls`/`mtls`), `certFile`/`keyFile`/`caRootFile`, `existingSecret` (required for TLS/mTLS) and a `service` sub-section. The chart now renders a Service for Falco to post alerts to.
+* Add support for the new `suite-run` and `suite-test` commands. The chart provisions a ConfigMap holding YAML test descriptions (either inline via `config.suite.descriptions` or via `config.suite.existingConfigMap`) and mounts it at `config.suite.descriptionDir`, passing the path to the binary as `--description-dir`. Suite commands always render as a Kubernetes Job.
+
 ## v0.3.4
 
 * Pass `--all` flag to event-generator binary to allow disabled rules to run, e.g. the k8saudit ruleset.

--- a/chart/event-generator/Chart.yaml
+++ b/chart/event-generator/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.4
+version: 0.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.10.0"
+appVersion: "0.13.0"

--- a/chart/event-generator/README.gotmpl
+++ b/chart/event-generator/README.gotmpl
@@ -1,6 +1,6 @@
 # Event-generator
 
-[event-generator](https://github.com/falcosecurity/event-generator) is a tool designed to generate events for both syscalls and k8s audit. The tool can be used to check if Falco is working properly. It does so by performing a variety of suspects actions which trigger security events. The event-event generator implements a [minimalistic framework](https://github.com/falcosecurity/event-generator/tree/master/events) which makes easy to implement new actions.
+[event-generator](https://github.com/falcosecurity/event-generator) is a tool designed to generate events for both syscalls and k8s audit. The tool can be used to check if Falco is working properly. It does so by performing a variety of suspect actions which trigger security events. The event-generator implements a [minimalistic framework](https://github.com/falcosecurity/event-generator/tree/main/events) which makes it easy to implement new actions.
 
 ## Introduction
 
@@ -32,14 +32,16 @@ In order to install the event-generator in a custom namespace run:
 kubectl create ns "ns-event-generator"
 helm install event-generator falcosecurity/event-generator --namespace "ns-event-generator"
 ```
-When the event-generator is installed using the default values in `values.yaml` file it is deployed using a k8s job, running the `run` command and, generates activity only for the k8s audit.
+With the default values in `values.yaml`, the chart deploys the event-generator as a k8s `deployment` running the `run` command against syscall actions in a loop.
 For more info check the next section.
 
 > **Tip**: List all releases using `helm list`, a release is a name used to track a specific deployment
 
 ### Commands, actions and options
 
-The event-generator tool accepts two commands: `run` and `test`. The first just generates activity, the later one, which is more sophisticated, also checks that for each generated activity Falco triggers the expected rule. Both of them accepts an argument that determines the actions to be performed:
+The event-generator tool accepts four commands: `run`, `test`, `suite-run` and `suite-test`. `run` and `test` exercise a hardcoded set of Go-coded actions; the suite commands consume YAML-described test scenarios instead. `test` and `suite-test` additionally verify that Falco triggered the expected rule for each generated action; see the [`suite` documentation](https://github.com/falcosecurity/event-generator/blob/main/docs/event-generator_suite.md) for the YAML format.
+
+`run` and `test` accept an argument that determines the actions to be performed:
 
 ```bash
 event-generator run/test [regexp]
@@ -50,63 +52,50 @@ Without arguments, all actions are performed; otherwise, only those actions matc
 ```bash
 event-generator test ^k8saudit
 ```
-The list of the supported actions can be found [here](https://github.com/falcosecurity/event-generator#list-actions)
+The list of the supported actions can be found [here](https://github.com/falcosecurity/event-generator#list-actions).
 
-Before diving in how this helm chart deploys and manages instances of the event-generator in kubernetes there are two more options that we need to talk about:
+Two more options apply to `run` and `test`:
 + `--loop` to run actions in a loop
 + `--sleep` to set the length of time to wait before running an action (default to 1s)
 
 ### Deployment modes in k8s
-Based on commands, actions and options configured the event-generator could be deployed as a k8s `job` or `deployment`. If the `config.loop` value is set a `deployment` is used since it is long running process, otherwise a `job`.
-A configuration like the one below, set in the `values.yaml` file, will deploy the even-generator using a `deployment` with the `run` command passed to it and will will generate activity only for the syscalls:
+Based on commands, actions and options configured the event-generator could be deployed as a k8s `job` or `deployment`. If `config.loop` is set, a `deployment` is used since it is a long running process, otherwise a `job`. Suite commands always run once and therefore always render as a `job`.
+
+For example, to run `test` once against the k8s audit actions instead of the defaults:
 ```yaml
 config:
-  # -- The event-generator accepts two commands (run, test):
-  # run: runs actions.
-  # test: runs and tests actions.
-  # For more info see: https://github.com/falcosecurity/event-generator
-  command: run
-  # -- Regular expression used to select the actions to be run.
-  actions: "^syscall"
-  # -- Runs in a loop the actions.
-  # If set to "true" the event-generator is deployed using a k8s deployment otherwise a k8s job.
-  loop: true
-  # -- The length of time to wait before running an action. Non-zero values should contain
-  # a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means no sleep. (default 100ms)
-  sleep: ""
-
-  grpc:
-    # -- Set it to true if you are deploying in "test" mode.
-    enabled: false
-    # -- Path to the Falco grpc socket.
-    bindAddress: "unix:///var/run/falco/falco.sock"
+  command: test
+  actions: "^k8saudit"
+  loop: false
 ```
 
-The following configuration will use a k8s `job` since we want to perform the k8s activity once and check that Falco reacts properly to those actions:
+When the command is `test` or `suite-test`, the event-generator runs an HTTP server that Falco posts alerts to. The chart provisions a Service exposing this server on port `8080` by default. Falco must be configured with `http_output.enabled=true` and `http_output.url` pointing at this Service (with default settings, `http://<release-name>-event-generator.<namespace>.svc.cluster.local:8080`), and with `json_output=true` so alerts are delivered as JSON. `suite-test` additionally requires Falco to append `proc.env` to its alert output fields (`append_output[]={"extra_fields": ["proc.env"]}`), since the event-generator matches alerts back to the originating test by inspecting a test UID it propagates through the process-chain environment. TLS or mTLS is configurable via `config.http.securityMode` and `config.http.tls.existingSecret`, which must reference a Kubernetes Secret holding the cert material; if the Secret stores its entries under non-default keys, override `config.http.tls.secretKeys.{cert,key,caRoot}` to match. For `suite-test`, set `config.suite.skipOutcomeVerification: true` to disable outcome verification entirely; the HTTP server and Service are not rendered, and the suite behaves like `suite-run`.
+
+### Test suites
+The `suite-run` and `suite-test` commands consume YAML test descriptions. There are two ways to provide them: set `config.suite.descriptions` to render them inline into a chart-managed ConfigMap, or set `config.suite.existingConfigMap` to mount a ConfigMap you already created. Either way, the descriptions land at `config.suite.descriptionDir` inside the pod, and each top-level map key becomes a separate file.
+
+Suite commands default to `securityContext.privileged: true`, since they could perform complex actions that require a wide range of capabilities. Set `securityContext.privileged: false` to opt out.
+
+A minimal `suite-run` deployment with inline descriptions:
 ```yaml
 config:
-  # -- The event-generator accepts two commands (run, test):
-  # run: runs actions.
-  # test: runs and tests actions.
-  # For more info see: https://github.com/falcosecurity/event-generator
-  command: test
-  # -- Regular expression used to select the actions to be run.
-  actions: "^k8saudit"
-  # -- Runs in a loop the actions.
-  # If set to "true" the event-generator is deployed using a k8s deployment otherwise a k8s job.
+  command: suite-run
   loop: false
-  # -- The length of time to wait before running an action. Non-zero values should contain
-  # a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means no sleep. (default 100ms)
-  sleep: ""
+  suite:
+    descriptions:
+      example.yaml: |
+        tests:
+          - name: read_sensitive_file
+            rule: Read sensitive file untrusted
+            runner: HostRunner
+            steps:
+              - type: syscall
+                name: open_etc_shadow
+                syscall: open
+                args: { pathname: /etc/shadow, flags: O_RDONLY }
+```
 
-  grpc:
-    # -- Set it to true if you are deploying in "test" mode.
-    enabled: true
-    # -- Path to the Falco grpc socket.
-    bindAddress: "unix:///var/run/falco/falco.sock"
-  ```
-
-Note that **grpc.enabled is set to true when running with the test command. Be sure that Falco exposes the grpc socket and emits output to it**.
+See the [`suite` documentation](https://github.com/falcosecurity/event-generator/blob/main/docs/event-generator_suite.md) for the YAML format.
 
 
 ## Uninstalling the Chart

--- a/chart/event-generator/README.md
+++ b/chart/event-generator/README.md
@@ -1,6 +1,6 @@
 # Event-generator
 
-[event-generator](https://github.com/falcosecurity/event-generator) is a tool designed to generate events for both syscalls and k8s audit. The tool can be used to check if Falco is working properly. It does so by performing a variety of suspects actions which trigger security events. The event-event generator implements a [minimalistic framework](https://github.com/falcosecurity/event-generator/tree/master/events) which makes easy to implement new actions.
+[event-generator](https://github.com/falcosecurity/event-generator) is a tool designed to generate events for both syscalls and k8s audit. The tool can be used to check if Falco is working properly. It does so by performing a variety of suspect actions which trigger security events. The event-generator implements a [minimalistic framework](https://github.com/falcosecurity/event-generator/tree/main/events) which makes it easy to implement new actions.
 
 ## Introduction
 
@@ -32,14 +32,16 @@ In order to install the event-generator in a custom namespace run:
 kubectl create ns "ns-event-generator"
 helm install event-generator falcosecurity/event-generator --namespace "ns-event-generator"
 ```
-When the event-generator is installed using the default values in `values.yaml` file it is deployed using a k8s job, running the `run` command and, generates activity only for the k8s audit.
+With the default values in `values.yaml`, the chart deploys the event-generator as a k8s `deployment` running the `run` command against syscall actions in a loop.
 For more info check the next section.
 
 > **Tip**: List all releases using `helm list`, a release is a name used to track a specific deployment
 
 ### Commands, actions and options
 
-The event-generator tool accepts two commands: `run` and `test`. The first just generates activity, the later one, which is more sophisticated, also checks that for each generated activity Falco triggers the expected rule. Both of them accepts an argument that determines the actions to be performed:
+The event-generator tool accepts four commands: `run`, `test`, `suite-run` and `suite-test`. `run` and `test` exercise a hardcoded set of Go-coded actions; the suite commands consume YAML-described test scenarios instead. `test` and `suite-test` additionally verify that Falco triggered the expected rule for each generated action; see the [`suite` documentation](https://github.com/falcosecurity/event-generator/blob/main/docs/event-generator_suite.md) for the YAML format.
+
+`run` and `test` accept an argument that determines the actions to be performed:
 
 ```bash
 event-generator run/test [regexp]
@@ -50,63 +52,50 @@ Without arguments, all actions are performed; otherwise, only those actions matc
 ```bash
 event-generator test ^k8saudit
 ```
-The list of the supported actions can be found [here](https://github.com/falcosecurity/event-generator#list-actions)
+The list of the supported actions can be found [here](https://github.com/falcosecurity/event-generator#list-actions).
 
-Before diving in how this helm chart deploys and manages instances of the event-generator in kubernetes there are two more options that we need to talk about:
+Two more options apply to `run` and `test`:
 + `--loop` to run actions in a loop
 + `--sleep` to set the length of time to wait before running an action (default to 1s)
 
 ### Deployment modes in k8s
-Based on commands, actions and options configured the event-generator could be deployed as a k8s `job` or `deployment`. If the `config.loop` value is set a `deployment` is used since it is long running process, otherwise a `job`.
-A configuration like the one below, set in the `values.yaml` file, will deploy the even-generator using a `deployment` with the `run` command passed to it and will will generate activity only for the syscalls:
+Based on commands, actions and options configured the event-generator could be deployed as a k8s `job` or `deployment`. If `config.loop` is set, a `deployment` is used since it is a long running process, otherwise a `job`. Suite commands always run once and therefore always render as a `job`.
+
+For example, to run `test` once against the k8s audit actions instead of the defaults:
 ```yaml
 config:
-  # -- The event-generator accepts two commands (run, test):
-  # run: runs actions.
-  # test: runs and tests actions.
-  # For more info see: https://github.com/falcosecurity/event-generator
-  command: run
-  # -- Regular expression used to select the actions to be run.
-  actions: "^syscall"
-  # -- Runs in a loop the actions.
-  # If set to "true" the event-generator is deployed using a k8s deployment otherwise a k8s job.
-  loop: true
-  # -- The length of time to wait before running an action. Non-zero values should contain
-  # a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means no sleep. (default 100ms)
-  sleep: ""
-
-  grpc:
-    # -- Set it to true if you are deploying in "test" mode.
-    enabled: false
-    # -- Path to the Falco grpc socket.
-    bindAddress: "unix:///var/run/falco/falco.sock"
+  command: test
+  actions: "^k8saudit"
+  loop: false
 ```
 
-The following configuration will use a k8s `job` since we want to perform the k8s activity once and check that Falco reacts properly to those actions:
+When the command is `test` or `suite-test`, the event-generator runs an HTTP server that Falco posts alerts to. The chart provisions a Service exposing this server on port `8080` by default. Falco must be configured with `http_output.enabled=true` and `http_output.url` pointing at this Service (with default settings, `http://<release-name>-event-generator.<namespace>.svc.cluster.local:8080`), and with `json_output=true` so alerts are delivered as JSON. `suite-test` additionally requires Falco to append `proc.env` to its alert output fields (`append_output[]={"extra_fields": ["proc.env"]}`), since the event-generator matches alerts back to the originating test by inspecting a test UID it propagates through the process-chain environment. TLS or mTLS is configurable via `config.http.securityMode` and `config.http.tls.existingSecret`, which must reference a Kubernetes Secret holding the cert material; if the Secret stores its entries under non-default keys, override `config.http.tls.secretKeys.{cert,key,caRoot}` to match. For `suite-test`, set `config.suite.skipOutcomeVerification: true` to disable outcome verification entirely; the HTTP server and Service are not rendered, and the suite behaves like `suite-run`.
+
+### Test suites
+The `suite-run` and `suite-test` commands consume YAML test descriptions. There are two ways to provide them: set `config.suite.descriptions` to render them inline into a chart-managed ConfigMap, or set `config.suite.existingConfigMap` to mount a ConfigMap you already created. Either way, the descriptions land at `config.suite.descriptionDir` inside the pod, and each top-level map key becomes a separate file.
+
+Suite commands default to `securityContext.privileged: true`, since they could perform complex actions that require a wide range of capabilities. Set `securityContext.privileged: false` to opt out.
+
+A minimal `suite-run` deployment with inline descriptions:
 ```yaml
 config:
-  # -- The event-generator accepts two commands (run, test):
-  # run: runs actions.
-  # test: runs and tests actions.
-  # For more info see: https://github.com/falcosecurity/event-generator
-  command: test
-  # -- Regular expression used to select the actions to be run.
-  actions: "^k8saudit"
-  # -- Runs in a loop the actions.
-  # If set to "true" the event-generator is deployed using a k8s deployment otherwise a k8s job.
+  command: suite-run
   loop: false
-  # -- The length of time to wait before running an action. Non-zero values should contain
-  # a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means no sleep. (default 100ms)
-  sleep: ""
+  suite:
+    descriptions:
+      example.yaml: |
+        tests:
+          - name: read_sensitive_file
+            rule: Read sensitive file untrusted
+            runner: HostRunner
+            steps:
+              - type: syscall
+                name: open_etc_shadow
+                syscall: open
+                args: { pathname: /etc/shadow, flags: O_RDONLY }
+```
 
-  grpc:
-    # -- Set it to true if you are deploying in "test" mode.
-    enabled: true
-    # -- Path to the Falco grpc socket.
-    bindAddress: "unix:///var/run/falco/falco.sock"
-  ```
-
-Note that **grpc.enabled is set to true when running with the test command. Be sure that Falco exposes the grpc socket and emits output to it**.
+See the [`suite` documentation](https://github.com/falcosecurity/event-generator/blob/main/docs/event-generator_suite.md) for the YAML format.
 
 ## Uninstalling the Chart
 To uninstall the `event-generator` release:
@@ -117,19 +106,32 @@ The command removes all the Kubernetes components associated with the chart and 
 
 ## Configuration
 
-The following table lists the main configurable parameters of the event-generator chart v0.3.4 and their default values. See `values.yaml` for full list.
+The following table lists the main configurable parameters of the event-generator chart v0.4.0 and their default values. See `values.yaml` for full list.
 
 ## Values
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Affinity, like the nodeSelector but with more expressive syntax. |
-| config.actions | string | `"^syscall"` | Regular expression used to select the actions to be run. |
-| config.command | string | `"run"` | The event-generator accepts two commands (run, test): run: runs actions. test: runs and tests actions. For more info see: https://github.com/falcosecurity/event-generator. |
-| config.grpc.bindAddress | string | `"unix:///run/falco/falco.sock"` | Path to the Falco grpc socket. |
-| config.grpc.enabled | bool | `false` | Set it to true if you are deploying in "test" mode. |
-| config.loop | bool | `true` | Runs in a loop the actions. If set to "true" the event-generator is deployed using a k8s deployment otherwise a k8s job. |
-| config.sleep | string | `""` | The length of time to wait before running an action. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means no sleep. (default 100ms) |
+| config.actions | string | `"^syscall"` | Regular expression used to select the actions to be run. Honored only when command is `run` or `test`. |
+| config.command | string | `"run"` | The event-generator accepts four commands: run: performs suspect actions. test: performs actions and verifies Falco alerts via HTTP. suite-run: runs YAML-described test suites without verification. suite-test: runs YAML-described test suites and verifies Falco alerts via HTTP. The `run` and `test` commands honor `actions`, `loop` and `sleep`; the suite commands honor the `suite` section below. Both `test` and `suite-test` additionally honor the `http` section. See https://github.com/falcosecurity/event-generator for the full reference. |
+| config.http.address | string | `"0.0.0.0:8080"` | Address the HTTP server binds to inside the pod. Use 0.0.0.0:<port> so the Service can reach it. |
+| config.http.securityMode | string | `"insecure"` | Security mode for the HTTP server: `insecure`, `tls` or `mtls`. |
+| config.http.service.nodePort | string | `""` | Static NodePort to expose when `type` is `NodePort` or `LoadBalancer`. Leave empty to let Kubernetes pick one from the cluster's node port range automatically. |
+| config.http.service.port | int | `8080` | Service port. The container listens on the port encoded in `address`. |
+| config.http.service.type | string | `"ClusterIP"` | Service type used to expose the HTTP server. Falco must be able to reach this Service. |
+| config.http.tls.existingSecret | string | `""` | Existing Kubernetes Secret holding the cert material. Required when `securityMode` is `tls` or `mtls`. The keys listed under `secretKeys` are projected at `/etc/falco/certs/{server.crt,server.key,ca.crt}` inside the pod and passed to the event-generator via the `--http-server-*` flags. |
+| config.http.tls.secretKeys.caRoot | string | `"ca.crt"` | Secret key holding the CA root certificate (only used when `securityMode` is `mtls`). Projected at `/etc/falco/certs/ca.crt`. |
+| config.http.tls.secretKeys.cert | string | `"server.crt"` | Secret key holding the server certificate. Projected at `/etc/falco/certs/server.crt`. |
+| config.http.tls.secretKeys.key | string | `"server.key"` | Secret key holding the server private key. Projected at `/etc/falco/certs/server.key`. |
+| config.loop | bool | `true` | Runs in a loop the actions. If set to "true", the event-generator is deployed as a k8s Deployment; otherwise as a Job. `suite-run` and `suite-test` ignore this value, resulting in the event-generator being always deployed as a Job. |
+| config.sleep | string | `""` | The length of time to wait before running an action. Non-zero values should contain a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means no sleep. (default 100ms). Honored only when command is `run` or `test`. |
+| config.suite.descriptionDir | string | `"/etc/event-generator/descriptions"` | In-pod mount point for the descriptions; passed to the event-generator binary as `--description-dir`. |
+| config.suite.descriptions | object | `{}` | Inline YAML descriptions rendered into a chart-managed ConfigMap. Each map key becomes a file name inside `descriptionDir`; the value is the YAML content. Ignored when `existingConfigMap` is set. Example: descriptions:   my_test.yaml: |     tests:       - name: example         rule: Read sensitive file untrusted         runner: HostRunner         steps:           - type: syscall             name: open_etc_shadow             syscall: open             args: { pathname: /etc/shadow, flags: O_RDONLY } |
+| config.suite.existingConfigMap | string | `""` | Existing ConfigMap holding YAML descriptions. When set, `descriptions` is ignored and the existing ConfigMap is mounted at `descriptionDir`. Each ConfigMap data key becomes a file in that directory. |
+| config.suite.reportFormat | string | `"text"` | Report format for `suite-test`: `text`, `json` or `yaml`. |
+| config.suite.skipOutcomeVerification | bool | `false` | Skip outcome verification (only meaningful for `suite-test`). When true, `suite-test` behaves like `suite-run` and the `http.*` settings are ignored. |
+| config.suite.timeout | string | `"1m"` | Maximum duration of the test suite execution. |
 | fullnameOverride | string | `""` | Used to override the chart full name. |
 | image | object | `{"pullPolicy":"IfNotPresent","repository":"falcosecurity/event-generator","tag":"latest"}` | Number of old history to retain to allow rollback (If not set, default Kubernetes value is set to 10) revisionHistoryLimit: 1 |
 | image.pullPolicy | string | `"IfNotPresent"` | Pull policy for the event-generator image |
@@ -141,5 +143,5 @@ The following table lists the main configurable parameters of the event-generato
 | podAnnotations | object | `{}` | Annotations to be added to the pod. |
 | podSecurityContext | object | `{}` | Security context for the pod. |
 | replicasCount | int | `1` | Number of replicas of the event-generator (meaningful when installed as a deployment). |
-| securityContext | object | `{}` | Security context for the containers. |
+| securityContext | object | `{}` | Security context for the containers. When command is `suite-run` or `suite-test`, the chart defaults `privileged: true` because those commands could perform complex actions that require a wide range of capabilities in order to properly work. Setting `privileged` explicitly here overrides that default. |
 | tolerations | list | `[]` | Tolerations to allow the pods to be scheduled on nodes whose taints the pod tolerates. |

--- a/chart/event-generator/templates/_helpers.tpl
+++ b/chart/event-generator/templates/_helpers.tpl
@@ -62,8 +62,88 @@ Create the name of the service account to use
 {{- end }}
 {{- end }}
 
-{{- define "grpc.unixSocketDir" -}}
-{{- if and .Values.config.grpc.enabled .Values.config.grpc.bindAddress (hasPrefix "unix://" .Values.config.grpc.bindAddress) -}}
-{{- .Values.config.grpc.bindAddress | trimPrefix "unix://" | dir -}}
+{{/*
+Returns "true" when command is suite-run or suite-test, "" otherwise.
+*/}}
+{{- define "event-generator.isSuiteCommand" -}}
+{{- if or (eq .Values.config.command "suite-run") (eq .Values.config.command "suite-test") -}}
+true
+{{- end -}}
+{{- end -}}
+
+{{/*
+Returns "true" when command is test or suite-test (i.e. an HTTP retriever is needed), "" otherwise.
+For suite-test, returns "" when config.suite.skipOutcomeVerification is true, since outcome verification (and therefore
+the HTTP retriever) is disabled.
+*/}}
+{{- define "event-generator.mustVerifyOutcome" -}}
+{{- if or (eq .Values.config.command "test") (and (eq .Values.config.command "suite-test") (not .Values.config.suite.skipOutcomeVerification)) -}}
+true
+{{- end -}}
+{{- end -}}
+
+{{/*
+Returns "true" when the workload should be a Deployment, "" otherwise. Suite commands always run once.
+*/}}
+{{- define "event-generator.useDeployment" -}}
+{{- if and .Values.config.loop (not (include "event-generator.isSuiteCommand" .)) -}}
+true
+{{- end -}}
+{{- end -}}
+
+{{/*
+Renders the argv to pass to the binary. Splits suite commands into two list items, and leaves non-suite commands as is.
+*/}}
+{{- define "event-generator.commandArgv" -}}
+{{- if include "event-generator.isSuiteCommand" . -}}
+- suite
+- {{ .Values.config.command | trimPrefix "suite-" }}
+{{- else -}}
+- {{ .Values.config.command }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Directory where TLS material from config.http.tls.existingSecret is projected inside the pod.
+*/}}
+{{- define "event-generator.certMountDir" -}}/etc/falco/certs{{- end -}}
+
+{{/*
+File paths projected under certMountDir from config.http.tls.existingSecret. Passed to the event-generator via
+--http-server-cert, --http-server-key and (mtls only) --http-client-ca.
+*/}}
+{{- define "event-generator.certFile" -}}{{ include "event-generator.certMountDir" . }}/server.crt{{- end -}}
+{{- define "event-generator.keyFile" -}}{{ include "event-generator.certMountDir" . }}/server.key{{- end -}}
+{{- define "event-generator.caRootFile" -}}{{ include "event-generator.certMountDir" . }}/ca.crt{{- end -}}
+
+{{/*
+Container securityContext. Defaults privileged=true unless the user explicitly sets `privileged` in
+.Values.securityContext.
+*/}}
+{{- define "event-generator.containerSecurityContext" -}}
+{{- $sc := deepCopy (.Values.securityContext | default dict) -}}
+{{- if and (include "event-generator.isSuiteCommand" .) (not (hasKey $sc "privileged")) -}}
+{{- $_ := set $sc "privileged" true -}}
+{{- end -}}
+{{- toYaml $sc -}}
+{{- end -}}
+
+{{/*
+Fails template rendering if the configuration is inconsistent.
+*/}}
+{{- define "event-generator.validate" -}}
+{{- $validCommands := list "run" "test" "suite-run" "suite-test" -}}
+{{- if not (has .Values.config.command $validCommands) -}}
+{{- fail (printf "config.command must be one of %v (got %q)" $validCommands .Values.config.command) -}}
+{{- end -}}
+{{- $validSecurityModes := list "insecure" "tls" "mtls" -}}
+{{- if not (has .Values.config.http.securityMode $validSecurityModes) -}}
+{{- fail (printf "config.http.securityMode must be one of %v (got %q)" $validSecurityModes .Values.config.http.securityMode) -}}
+{{- end -}}
+{{- if and (ne .Values.config.http.securityMode "insecure") (not .Values.config.http.tls.existingSecret) -}}
+{{- fail (printf "config.http.tls.existingSecret must be set when config.http.securityMode is %q" .Values.config.http.securityMode) -}}
+{{- end -}}
+{{- if and (include "event-generator.isSuiteCommand" .) (empty .Values.config.suite.existingConfigMap) (empty .Values.config.suite.descriptions) -}}
+{{- fail "config.suite.descriptions or config.suite.existingConfigMap must be set when config.command is suite-run or suite-test" -}}
 {{- end -}}
 {{- end -}}

--- a/chart/event-generator/templates/configmap.yaml
+++ b/chart/event-generator/templates/configmap.yaml
@@ -1,0 +1,13 @@
+{{- if and (include "event-generator.isSuiteCommand" .) (empty .Values.config.suite.existingConfigMap) -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "event-generator.fullname" . }}-descriptions
+  labels:
+    {{- include "event-generator.labels" . | nindent 4 }}
+data:
+  {{- range $name, $content := .Values.config.suite.descriptions }}
+  {{ $name }}: |-
+    {{- $content | nindent 4 }}
+  {{- end }}
+{{- end -}}

--- a/chart/event-generator/templates/deployment.yaml
+++ b/chart/event-generator/templates/deployment.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.config.loop -}}
+{{- if include "event-generator.useDeployment" . -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/chart/event-generator/templates/job.yaml
+++ b/chart/event-generator/templates/job.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.config.loop -}}
+{{- if not (include "event-generator.useDeployment" .) -}}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/chart/event-generator/templates/pod-template.tpl
+++ b/chart/event-generator/templates/pod-template.tpl
@@ -1,4 +1,11 @@
 {{- define "event-generator.podTemplate" -}}
+{{- include "event-generator.validate" . -}}
+{{- $isSuiteCommand := include "event-generator.isSuiteCommand" . -}}
+{{- $mustVerifyOutcome := include "event-generator.mustVerifyOutcome" . -}}
+{{- $http := .Values.config.http -}}
+{{- $suite := .Values.config.suite -}}
+{{- $descriptionsConfigMap := default (printf "%s-descriptions" (include "event-generator.fullname" .)) $suite.existingConfigMap -}}
+{{- $mustVerifyOutcomeSecurely := and $mustVerifyOutcome (ne $http.securityMode "insecure") -}}
 metadata:
   {{- with .Values.podAnnotations }}
   annotations:
@@ -17,12 +24,13 @@ spec:
   containers:
     - name: {{ .Chart.Name }}
       securityContext:
-        {{- toYaml .Values.securityContext | nindent 8 }}
+        {{- include "event-generator.containerSecurityContext" . | nindent 8 }}
       image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
       imagePullPolicy: {{ .Values.image.pullPolicy }}
-      command: 
-        - /bin/event-generator 
-        - {{ .Values.config.command }}
+      command:
+        - /bin/event-generator
+        {{- include "event-generator.commandArgv" . | nindent 8 }}
+        {{- if not $isSuiteCommand }}
         - --all
         {{- if .Values.config.actions }}
         - {{ .Values.config.actions }}
@@ -31,27 +39,76 @@ spec:
         - --loop
         {{- end }}
         {{- if .Values.config.sleep }}
-        - --sleep={{- .Values.config.sleep }}
+        - --sleep={{ .Values.config.sleep }}
         {{- end }}
-        {{- if .Values.config.grpc.enabled }}
-        - --grpc-unix-socket={{- .Values.config.grpc.bindAddress }}
         {{- end }}
-      env:
-      - name: FALCO_EVENT_GENERATOR_NAMESPACE
-        valueFrom:
-          fieldRef:
-            fieldPath: metadata.namespace
-      {{- if .Values.config.grpc.enabled }}
-      volumeMounts:
-      - mountPath: {{ include "grpc.unixSocketDir" . }} 
-        name: unix-socket-dir
+        {{- if $isSuiteCommand }}
+        - --description-dir={{ $suite.descriptionDir }}
+        - --timeout={{ $suite.timeout }}
+        {{- if eq .Values.config.command "suite-test" }}
+        - --report-format={{ $suite.reportFormat }}
+        {{- if $suite.skipOutcomeVerification }}
+        - --skip-outcome-verification
+        {{- end }}
+        {{- end }}
+        {{- end }}
+        {{- if $mustVerifyOutcome }}
+        - --http-server-address={{ $http.address }}
+        - --http-server-security-mode={{ $http.securityMode }}
+        {{- if $mustVerifyOutcomeSecurely }}
+        - --http-server-cert={{ include "event-generator.certFile" . }}
+        - --http-server-key={{ include "event-generator.keyFile" . }}
+        {{- if eq $http.securityMode "mtls" }}
+        - --http-client-ca={{ include "event-generator.caRootFile" . }}
+        {{- end }}
+        {{- end }}
+        {{- end }}
+      {{- if $mustVerifyOutcome }}
+      ports:
+        - name: http
+          containerPort: {{ $http.address | splitList ":" | last | int }}
+          protocol: TCP
       {{- end }}
-  {{- if .Values.config.grpc.enabled }}
+      env:
+        - name: FALCO_EVENT_GENERATOR_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+      {{- if or $isSuiteCommand $mustVerifyOutcomeSecurely }}
+      volumeMounts:
+        {{- if $isSuiteCommand }}
+        - name: descriptions
+          mountPath: {{ $suite.descriptionDir }}
+          readOnly: true
+        {{- end }}
+        {{- if $mustVerifyOutcomeSecurely }}
+        - name: certs
+          mountPath: {{ include "event-generator.certMountDir" . }}
+          readOnly: true
+        {{- end }}
+      {{- end }}
+  {{- if or $isSuiteCommand $mustVerifyOutcomeSecurely }}
   volumes:
-  - hostPath:
-      path: {{ include "grpc.unixSocketDir" . }} 
-    name: unix-socket-dir       
-  {{- end }}          
+    {{- if $isSuiteCommand }}
+    - name: descriptions
+      configMap:
+        name: {{ $descriptionsConfigMap }}
+    {{- end }}
+    {{- if $mustVerifyOutcomeSecurely }}
+    - name: certs
+      secret:
+        secretName: {{ $http.tls.existingSecret }}
+        items:
+          - key: {{ $http.tls.secretKeys.cert }}
+            path: {{ include "event-generator.certFile" . | base }}
+          - key: {{ $http.tls.secretKeys.key }}
+            path: {{ include "event-generator.keyFile" . | base }}
+          {{- if eq $http.securityMode "mtls" }}
+          - key: {{ $http.tls.secretKeys.caRoot }}
+            path: {{ include "event-generator.caRootFile" . | base }}
+          {{- end }}
+    {{- end }}
+  {{- end }}
   {{- with .Values.nodeSelector }}
   nodeSelector:
     {{- toYaml . | nindent 4 }}
@@ -64,7 +121,7 @@ spec:
   tolerations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  {{- if not .Values.config.loop }}
+  {{- if not (include "event-generator.useDeployment" .) }}
   restartPolicy: Never
   {{- end }}
 {{- end -}}

--- a/chart/event-generator/templates/service.yaml
+++ b/chart/event-generator/templates/service.yaml
@@ -1,0 +1,21 @@
+{{- if include "event-generator.mustVerifyOutcome" . -}}
+{{- $containerPort := .Values.config.http.address | splitList ":" | last | int -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "event-generator.fullname" . }}
+  labels:
+    {{- include "event-generator.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.config.http.service.type }}
+  ports:
+    - port: {{ .Values.config.http.service.port }}
+      targetPort: {{ $containerPort }}
+      protocol: TCP
+      name: http
+      {{- with .Values.config.http.service.nodePort }}
+      nodePort: {{ . }}
+      {{- end }}
+  selector:
+    {{- include "event-generator.selectorLabels" . | nindent 4 }}
+{{- end -}}

--- a/chart/event-generator/values.yaml
+++ b/chart/event-generator/values.yaml
@@ -31,7 +31,9 @@ podAnnotations: {}
 podSecurityContext: {}
   # fsGroup: 2000
 
-# -- Security context for the containers.
+# -- Security context for the containers. When command is `suite-run` or `suite-test`, the chart defaults
+# `privileged: true` because those commands could perform complex actions that require a wide range of capabilities in
+# order to properly work. Setting `privileged` explicitly here overrides that default.
 securityContext: {}
   # capabilities:
   #   drop:
@@ -50,22 +52,83 @@ tolerations: []
 affinity: {}
 
 config:
-  # -- The event-generator accepts two commands (run, test):
-  # run: runs actions.
-  # test: runs and tests actions.
-  # For more info see: https://github.com/falcosecurity/event-generator.
+  # -- The event-generator accepts four commands:
+  # run: performs suspect actions.
+  # test: performs actions and verifies Falco alerts via HTTP.
+  # suite-run: runs YAML-described test suites without verification.
+  # suite-test: runs YAML-described test suites and verifies Falco alerts via HTTP.
+  # The `run` and `test` commands honor `actions`, `loop` and `sleep`; the suite commands honor the `suite` section
+  # below. Both `test` and `suite-test` additionally honor the `http` section. See
+  # https://github.com/falcosecurity/event-generator for the full reference.
   command: run
-  # -- Regular expression used to select the actions to be run.
+
+  # -- Regular expression used to select the actions to be run. Honored only when command is `run` or `test`.
   actions: "^syscall"
-  # -- Runs in a loop the actions.
-  # If set to "true" the event-generator is deployed using a k8s deployment otherwise a k8s job.
+  # -- Runs in a loop the actions. If set to "true", the event-generator is deployed as a k8s Deployment; otherwise
+  # as a Job. `suite-run` and `suite-test` ignore this value, resulting in the event-generator being always deployed as
+  # a Job.
   loop: true
-  # -- The length of time to wait before running an action. Non-zero values should contain
-  # a corresponding time unit (e.g. 1s, 2m, 3h). A value of zero means no sleep. (default 100ms)
+  # -- The length of time to wait before running an action. Non-zero values should contain a corresponding time unit
+  # (e.g. 1s, 2m, 3h). A value of zero means no sleep. (default 100ms). Honored only when command is `run` or `test`.
   sleep: ""
 
-  grpc:
-    # -- Set it to true if you are deploying in "test" mode.
-    enabled: false
-    # -- Path to the Falco grpc socket.
-    bindAddress: "unix:///run/falco/falco.sock"
+  # HTTP alert retriever configuration, used to receive alerts from Falco. Honored only when command is `test` or
+  # `suite-test`.
+  http:
+    # -- Address the HTTP server binds to inside the pod. Use 0.0.0.0:<port> so the Service can reach it.
+    address: "0.0.0.0:8080"
+    # -- Security mode for the HTTP server: `insecure`, `tls` or `mtls`.
+    securityMode: insecure
+    tls:
+      # -- Existing Kubernetes Secret holding the cert material. Required when `securityMode` is `tls` or `mtls`.
+      # The keys listed under `secretKeys` are projected at `/etc/falco/certs/{server.crt,server.key,ca.crt}` inside
+      # the pod and passed to the event-generator via the `--http-server-*` flags.
+      existingSecret: ""
+      # Mapping from `existingSecret` keys to the file names projected inside the pod. Defaults assume the Secret
+      # keys match the projected file names; override individual entries if your Secret uses different key names.
+      secretKeys:
+        # -- Secret key holding the server certificate. Projected at `/etc/falco/certs/server.crt`.
+        cert: "server.crt"
+        # -- Secret key holding the server private key. Projected at `/etc/falco/certs/server.key`.
+        key: "server.key"
+        # -- Secret key holding the CA root certificate (only used when `securityMode` is `mtls`). Projected at
+        # `/etc/falco/certs/ca.crt`.
+        caRoot: "ca.crt"
+    service:
+      # -- Service type used to expose the HTTP server. Falco must be able to reach this Service.
+      type: ClusterIP
+      # -- Service port. The container listens on the port encoded in `address`.
+      port: 8080
+      # -- Static NodePort to expose when `type` is `NodePort` or `LoadBalancer`. Leave empty to let Kubernetes
+      # pick one from the cluster's node port range automatically.
+      nodePort: ""
+
+  # Test suite configuration. Honored only when command is `suite-run` or `suite-test`.
+  suite:
+    # -- Inline YAML descriptions rendered into a chart-managed ConfigMap. Each map key becomes a file name inside
+    # `descriptionDir`; the value is the YAML content. Ignored when `existingConfigMap` is set.
+    # Example:
+    # descriptions:
+    #   my_test.yaml: |
+    #     tests:
+    #       - name: example
+    #         rule: Read sensitive file untrusted
+    #         runner: HostRunner
+    #         steps:
+    #           - type: syscall
+    #             name: open_etc_shadow
+    #             syscall: open
+    #             args: { pathname: /etc/shadow, flags: O_RDONLY }
+    descriptions: {}
+    # -- Existing ConfigMap holding YAML descriptions. When set, `descriptions` is ignored and the existing
+    # ConfigMap is mounted at `descriptionDir`. Each ConfigMap data key becomes a file in that directory.
+    existingConfigMap: ""
+    # -- In-pod mount point for the descriptions; passed to the event-generator binary as `--description-dir`.
+    descriptionDir: "/etc/event-generator/descriptions"
+    # -- Maximum duration of the test suite execution.
+    timeout: "1m"
+    # -- Report format for `suite-test`: `text`, `json` or `yaml`.
+    reportFormat: "text"
+    # -- Skip outcome verification (only meaningful for `suite-test`). When true, `suite-test` behaves like `suite-run`
+    # and the `http.*` settings are ignored.
+    skipOutcomeVerification: false

--- a/docs/event-generator_suite_run.md
+++ b/docs/event-generator_suite_run.md
@@ -99,8 +99,8 @@ cat ./samples/steps_syscall.yaml | sudo event-generator suite run
 
 The event-generator is distributed as the
 [`falcosecurity/event-generator`](https://hub.docker.com/r/falcosecurity/event-generator) Docker image, so `suite run`
-can be invoked inside a container instead of installing the binary on the host. The command performs real system calls
-and modifies system state, so the container must be started with `--privileged`.
+can be invoked inside a container instead of installing the binary on the host. The command could perform complex
+actions that require a wide range of capabilities, so the container must be started with `--privileged`.
 
 Feed the description through standard input:
 

--- a/docs/event-generator_suite_test.md
+++ b/docs/event-generator_suite_test.md
@@ -136,8 +136,8 @@ sudo event-generator suite test --description-dir ./samples --skip-outcome-verif
 
 The event-generator is distributed as the
 [`falcosecurity/event-generator`](https://hub.docker.com/r/falcosecurity/event-generator) Docker image, so `suite test`
-can be invoked inside a container instead of installing the binary on the host. The command performs real system calls
-and modifies system state, so the container must be started with `--privileged`.
+can be invoked inside a container instead of installing the binary on the host. The command could perform complex
+actions that require a wide range of capabilities, so the container must be started with `--privileged`.
 
 Falco must also be able to reach the alert-collection HTTP server hosted by the event-generator inside the container.
 Publish the container's port to the host's loopback interface only (`-p 127.0.0.1:8080:8080`) and bind the server to


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our [CONTRIBUTING.md](../CONTRIBUTING.md).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note: it's really useful for the changelog!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind documentation

> /kind tests

/kind feature

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area commands

> /area pkg

> /area events

/area chart

> /area automation

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR bumps the `event-generator` version in the chart to `0.13.0`, replacing values involving the legacy gRPC alert retriever mechanism with the new HTTP one.

The PR updates `config.command` to accept four values: `run`, `test`, `suite-run` and `suite-test`. Moreover, it removes `config.grpc` section and replaces it with `config.http`. `config.http` exposes `address`, `securityMode` (`insecure`/`tls`/`mtls`), `certFile`/`keyFile`/`caRootFile`, `existingSecret` (required for TLS/mTLS) and a `service` sub-section.

If `config.command` is `test` or `suite-test`, a Service for Falco to post alerts to is created.

If `config.command` is `suite-run` or `suite-test`, the chart provisions a ConfigMap holding YAML test descriptions (either inline via `config.suite.descriptions` or via `config.suite.existingConfigMap`) and mounts it at `config.suite.descriptionDir`, passing the path to the binary as `--description-dir`.

Suite commands always render as a Kubernetes Job, as opposite to `run` and `test` commands, which can run as a Deployment in case `config.loop` is set to true.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
