### PR TITLE
feat(suite): extend process resource to support fileless execution

### DIFF
--- a/pkg/container/builder/builder.go
+++ b/pkg/container/builder/builder.go
@@ -251,7 +251,7 @@ func (c *dockerContainer) Start(ctx context.Context) (err error) {
 
 	// Retrieve base image.
 	baseImageName := c.baseImageName
-	if err := pullImage(ctx, client, baseImageName, c.baseImagePullPolicy); err != nil {
+	if err := c.pullImage(ctx, client, baseImageName, c.baseImagePullPolicy); err != nil {
 		return fmt.Errorf("error pulling base image %q: %w", baseImageName, err)
 	}
 	logger.V(1).Info("Pulled base image", "imageName", baseImageName)
@@ -383,12 +383,13 @@ func (c *dockerContainer) teardown(ctx context.Context, mustStopContainer bool) 
 
 var errImageNotFoundLocally = fmt.Errorf("image not found locally")
 
-// pullImage pulls the image with the provided image name, leveraging the provided docker client and using the provided
-// image pull policy.
-func pullImage(ctx context.Context, client *dockerclient.Client, imageName string, policy ImagePullPolicy) error {
+// pullImage pulls the image with the provided image name, leveraging the provided docker client and respecting the
+// provided image pull policy.
+func (c *dockerContainer) pullImage(ctx context.Context, client *dockerclient.Client, imageName string,
+	policy ImagePullPolicy) error {
 	switch policy {
 	case ImagePullPolicyAlways:
-		if err := pullRemoteImage(ctx, client, imageName); err != nil {
+		if err := c.pullRemoteImage(ctx, client, imageName); err != nil {
 			return fmt.Errorf("error pulling from remote: %w", err)
 		}
 		return nil
@@ -414,7 +415,7 @@ func pullImage(ctx context.Context, client *dockerclient.Client, imageName strin
 		}
 
 		// Otherwise, try to pull it from remote.
-		if err := pullRemoteImage(ctx, client, imageName); err != nil {
+		if err := c.pullRemoteImage(ctx, client, imageName); err != nil {
 			return fmt.Errorf("error pulling from remote: %w", err)
 		}
 		return nil
@@ -425,7 +426,8 @@ func pullImage(ctx context.Context, client *dockerclient.Client, imageName strin
 
 // pullRemoteImage requests docker to pull the image with the provided image name from the remote registry, leveraging
 // the provided docker client.
-func pullRemoteImage(ctx context.Context, client *dockerclient.Client, imageName string) error {
+func (c *dockerContainer) pullRemoteImage(ctx context.Context, client *dockerclient.Client, imageName string) error {
+	c.logger.V(1).Info("Pulling image from remote registry", "imageName", imageName)
 	reader, err := client.ImagePull(ctx, imageName, dockerimage.PullOptions{})
 	if err != nil {
 		return err

--- a/pkg/process/builder/builder.go
+++ b/pkg/process/builder/builder.go
@@ -45,6 +45,7 @@ type builder struct {
 	env          []string
 	username     string
 	capabilities string
+	isFileLess   bool
 }
 
 // Verify that builder implements process.Builder interface.
@@ -84,6 +85,10 @@ func (b *builder) SetCapabilities(capabilities string) {
 	b.capabilities = capabilities
 }
 
+func (b *builder) SetFileLess(isFileLess bool) {
+	b.isFileLess = isFileLess
+}
+
 var (
 	// defaultSimExePathPrefix defines the prefix used to generate a random simulated executable path.
 	defaultSimExePathPrefix = filepath.Join(os.TempDir(), "event-generator")
@@ -93,6 +98,27 @@ var (
 
 func (b *builder) Build(ctx context.Context, logger logr.Logger, command string) process.Process {
 	defer b.reset()
+
+	if b.isFileLess {
+		// Setup process command. The command to run is now set to "", and is later set in osProcess.Start() to
+		// /proc/<pid>/fd/<fd> (this is also the value set in osProcess.Start() for argv[0] is b.arg0 is now empty).
+		cmd := exec.CommandContext(ctx, "", splitArgs(b.args)...) //nolint:gosec // Disable G204
+		cmd.Args[0] = b.arg0
+		cmd.Env = b.env
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		proc := &osProcess{
+			logger:       logger,
+			command:      command,
+			simExePath:   "",
+			username:     b.username,
+			capabilities: "",
+			cmd:          cmd,
+			isFileLess:   true,
+			started:      false,
+		}
+		return proc
+	}
 
 	// If the user doesn't provide an executable path, we must generate a random path.
 	var simExePath string
@@ -145,6 +171,7 @@ func (b *builder) Build(ctx context.Context, logger logr.Logger, command string)
 		username:     b.username,
 		capabilities: capabilities,
 		cmd:          cmd,
+		isFileLess:   false,
 		started:      false,
 	}
 
@@ -160,6 +187,7 @@ func (b *builder) reset() {
 	b.env = nil
 	b.username = ""
 	b.capabilities = ""
+	b.isFileLess = false
 }
 
 // splittingArgsRegex allows to split space-separated arguments, keeping together space-separated words under the same
@@ -195,6 +223,7 @@ type osProcess struct {
 	simExePath   string
 	username     string
 	capabilities string
+	isFileLess   bool
 
 	// cmd is the underlying command object.
 	cmd *exec.Cmd
@@ -206,6 +235,9 @@ type osProcess struct {
 	// simulated executable path, that has been created. If no directories have been created, it is empty. If non-empty,
 	// this is the directory that must be deleted upon process resources release.
 	firstCreatedSimExePathDir string
+	// memFDFile is the memfd file storing the executable in fileless mode. It is only populated in case isFileLess is
+	// true; it is nil otherwise. If non-nil, this file must be closed upon process resources release.
+	memFDFile *os.File
 }
 
 // Verify that osProcess implements process.Process interface.
@@ -225,6 +257,31 @@ func (p *osProcess) Start() (err error) {
 	commandPath, err := exec.LookPath(p.command)
 	if err != nil && !errors.Is(err, exec.ErrDot) {
 		return fmt.Errorf("error retrieving command path: %w", err)
+	}
+
+	if p.isFileLess {
+		// Create a memfd file with the content of the command executable.
+		memFDFile, err := createMemFDFile(commandPath)
+		if err != nil {
+			return fmt.Errorf("error creating fileless executable (memfd file): %w", err)
+		}
+		defer p.closeFileIfErr(memFDFile, &err)
+		memFDFilePath := memFDFile.Name()
+		p.logger.V(1).Info("Created fileless executable (memfd file)", "path", memFDFilePath)
+
+		// Set the command path to the memfd file name (which is in the form /proc/<pid>/fd/<fd>). Set argv[0] to the
+		// same value if this latter is empty and then, start the process.
+		p.cmd.Path = memFDFilePath
+		if p.cmd.Args[0] == "" {
+			p.cmd.Args[0] = memFDFilePath
+		}
+		if err := p.cmd.Start(); err != nil {
+			return err
+		}
+
+		p.started = true
+		p.memFDFile = memFDFile
+		return nil
 	}
 
 	// Determine if the process must be run by the current user/group or not. If a user different from the current one
@@ -330,6 +387,49 @@ func (p *osProcess) Start() (err error) {
 	p.userCreated = userCreated
 	p.firstCreatedSimExePathDir = firstCreatedSimExePathDir
 	return nil
+}
+
+// createMemFDFile creates a memfd file storing the content of the executable at the provided path.
+func createMemFDFile(exePath string) (file *os.File, err error) {
+	srcFile, err := os.Open(exePath) //nolint:gosec // Disable G304
+	if err != nil {
+		return nil, fmt.Errorf("error opening source file: %w", err)
+	}
+	defer func() {
+		if e := srcFile.Close(); e != nil {
+			e := fmt.Errorf("error closing source file: %w", e)
+			if err != nil {
+				err = fmt.Errorf("%w; %w", err, e)
+			} else {
+				err = e
+			}
+		}
+	}()
+
+	fd, err := unix.MemfdCreate("event-generator", unix.MFD_CLOEXEC)
+	if err != nil {
+		return nil, fmt.Errorf("error creating memfd file: %w", err)
+	}
+
+	dstFile := os.NewFile(uintptr(fd), fmt.Sprintf("/proc/%d/fd/%d", os.Getpid(), fd))
+	if _, err := io.Copy(dstFile, srcFile); err != nil {
+		if e := dstFile.Close(); e != nil {
+			return nil, fmt.Errorf("error copying data: %w; error closing memfd file: %w", err, e)
+		}
+		return nil, fmt.Errorf("error copying data: %w", err)
+	}
+
+	return dstFile, nil
+}
+
+// closeFileIfErr closes the file if the provided error pointer points to an error.
+func (p *osProcess) closeFileIfErr(file *os.File, err *error) { //nolint:gocritic // Disable ptrToRefParam
+	if *err != nil {
+		logger := p.logger.WithValues("fd", int(file.Fd()), "path", file.Name())
+		if err := file.Close(); err != nil {
+			logger.Error(err, "Error closing file")
+		}
+	}
 }
 
 // findOrCreateUser finds or creates the user with the provided username. It returns information about the user.
@@ -501,7 +601,24 @@ func (p *osProcess) releaseResources() {
 	defer func() {
 		p.started = false
 		p.userCreated = false
+		p.firstCreatedSimExePathDir = ""
+		p.memFDFile = nil
 	}()
+
+	if p.isFileLess {
+		if memFDFile := p.memFDFile; memFDFile != nil {
+			fd := int(memFDFile.Fd())
+			logger := p.logger.WithValues("fd", fd, "path", memFDFile.Name())
+			if err := p.memFDFile.Close(); err != nil {
+				logger.Error(err, "Error closing memfd file")
+			} else {
+				logger.V(1).Info("Closed memfd file")
+			}
+		}
+
+		// No other resources need to be released in fileless mode.
+		return
+	}
 
 	username := p.username
 	if p.userCreated {

--- a/pkg/process/process.go
+++ b/pkg/process/process.go
@@ -24,7 +24,7 @@ import (
 // Builder allows to build a new process.
 type Builder interface {
 	// SetSimExePath sets the "simulated" executable path. This sets the executable path accessible through
-	// `readlink -f /proc/<pid/exepath` for the started process. The underlying implementation ensures the existence of
+	// `readlink -f /proc/<pid>/exe` for the started process. The underlying implementation ensures the existence of
 	// each segment of the provided path, by possibly creating some of them. Path segments contextually created are
 	// automatically removed after the process resources are released. If unset or empty, it is randomly generated.
 	SetSimExePath(simExePath string)
@@ -46,6 +46,15 @@ type Builder interface {
 	// SetCapabilities sets the capabilities that must be set on the process executable file. The syntax follows the
 	// conventions specified by cap_from_text(3). If unset or empty, it defaults to 'all=iep'.
 	SetCapabilities(capabilities string)
+	// SetFileLess sets the process as "fileless" or not. If set to true, the process executable is placed in the memory
+	// associated with a newly created memfd file, and the execution starts from there instead of starting from the file
+	// system. resulting in-memory executable is a memfd file created just before the process execution is started.
+	// If true, only settings associated with the following APIs are taken into account:
+	// - SetArg0
+	// - SetArgs
+	// - SetEnv
+	// If unset, it defaults to false.
+	SetFileLess(isFileLess bool)
 	// Build builds the process, setting the logger managing its lifecycle and the command that it is going to run.
 	// The provided context can be used at any time to cancel the process execution after it is started.
 	// After calling Build, the Builder process-related configuration is cleared and the Builder can be reused to build

--- a/pkg/test/loader/loader.go
+++ b/pkg/test/loader/loader.go
@@ -727,6 +727,10 @@ type TestResourceProcessSpec struct {
 	Name *string `yaml:"procName,omitempty" mapstructure:"procName"`
 	// Env is the set of environment variables that must be provided to the process (in addition to the default ones).
 	Env map[string]string `yaml:"env,omitempty" mapstructure:"env"`
+	// FileLess allows to specify if the process must be fileless or not. If set to true, the process executable is
+	// placed in the memory associated with a newly created memfd file, and the execution starts from there instead of
+	// starting from the file system. If true, fields other than Exe, Args and Env are not supported.
+	FileLess *bool `yaml:"fileLess,omitempty" mapstructure:"fileLess"`
 }
 
 // TestStep describes a test step.

--- a/pkg/test/loader/schema/jsonschemas/context.schema.json
+++ b/pkg/test/loader/schema/jsonschemas/context.schema.json
@@ -7,7 +7,7 @@
   "properties": {
     "container": {
       "description": "The container context containing information regarding the container that will run a test",
-      "type": "object",
+      "type": ["object", "null"],
       "properties": {
         "image": {
           "description": "The name the base event-generator image must be tagged with before being used to spawn the container",

--- a/pkg/test/loader/schema/jsonschemas/resources/process.schema.json
+++ b/pkg/test/loader/schema/jsonschemas/resources/process.schema.json
@@ -39,6 +39,11 @@
         "minLength": 1
       }
     },
+    "fileLess": {
+      "description": "A boolean value allowing to mark the process as fileless. If set to true, the process executable is placed in the memory associated with a newly created memfd file, and the execution starts from there instead of starting from the file system. If true, fields other than 'exe', 'args' and 'env' are not supported",
+      "type": "boolean",
+      "default": false
+    },
     "x-metadata": {
       "not": {},
       "type": "object",
@@ -51,5 +56,21 @@
         }
       }
     }
-  }
+  },
+  "allOf": [
+    {
+      "if": {
+        "required": ["fileLess"],
+        "properties": {
+          "fileLess": { "const": true }
+        }
+      },
+      "then": {
+        "properties": {
+          "exePath": false,
+          "procName": false
+        }
+      }
+    }
+  ]
 }

--- a/pkg/test/resource/builder/builder.go
+++ b/pkg/test/resource/builder/builder.go
@@ -160,6 +160,7 @@ func buildFD(logger logr.Logger, resourceName string,
 func buildProcess(logger logr.Logger, resourceName string, processBuilder process.Builder,
 	procSpec *loader.TestResourceProcessSpec) resource.Resource {
 	var simExePath, name, arg0, args string
+	var isFileLess bool
 	if procSpec.ExePath != nil {
 		simExePath = *procSpec.ExePath
 	}
@@ -172,8 +173,11 @@ func buildProcess(logger logr.Logger, resourceName string, processBuilder proces
 	if procSpec.Args != nil {
 		args = *procSpec.Args
 	}
+	if procSpec.FileLess != nil {
+		isFileLess = *procSpec.FileLess
+	}
 	procEnv := buildProcEnv(procSpec.Env)
-	return processresource.New(logger, resourceName, processBuilder, simExePath, name, arg0, args, procEnv)
+	return processresource.New(logger, resourceName, processBuilder, simExePath, name, arg0, args, procEnv, isFileLess)
 }
 
 func buildProcEnv(userEnv map[string]string) []string {

--- a/pkg/test/resource/process/process.go
+++ b/pkg/test/resource/process/process.go
@@ -47,12 +47,13 @@ var processCommand = "cat"
 
 // New creates a new process resource.
 func New(logger logr.Logger, resourceName string, processBuilder process.Builder, simExePath, name, arg0, args string,
-	env []string) resource.Resource {
+	env []string, isFileLess bool) resource.Resource {
 	processBuilder.SetSimExePath(simExePath)
 	processBuilder.SetName(name)
 	processBuilder.SetArg0(arg0)
 	processBuilder.SetArgs(args)
 	processBuilder.SetEnv(env)
+	processBuilder.SetFileLess(isFileLess)
 	proc := processBuilder.Build(context.Background(), logger, processCommand)
 
 	p := &procRes{

--- a/samples/expected_outcome.yaml
+++ b/samples/expected_outcome.yaml
@@ -17,7 +17,7 @@ tests:
           len: 16
     expectedOutcome:
       source: syscall
-      priority: WARNING
+      priority: warning
   - name: test_expected_outcome_loose
     rule: "Read sensitive file untrusted"
     description: "Demonstrates the loose `expectedOutcome: {}` form: matches any alert produced for the rule"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our [CONTRIBUTING.md](../CONTRIBUTING.md).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note: it's really useful for the changelog!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

/kind documentation

> /kind tests

/kind feature

> If this PR prepares a chart release, uncomment:

> /kind chart-release

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area commands

/area pkg

> /area events

> /area chart

> /area automation

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR extends the `process` resource to support "fileless" execution leveraging memfd files. If "fileLess" field is set to true, the process executable is placed in the memory associated with a newly created memfd file, and the execution starts from there instead of starting from the file system. If the process resource is created in fileless mode, fields other than `exe`, `args` and `env` are not supported. This allows to test Falco rules like `Fileless execution via memfd_create` (https://github.com/falcosecurity/rules/blob/falco-rules-5.1.0/rules/falco_rules.yaml#L1253)

Moreover, it makes `context.container` nullable by marking both "object" and "null" as valid types in the corresponding JSON schema section. This allows to concisely write tests for rules that must trigger for both containerized and non-containerized workloads.
E.g.:
```YAML
tests:
  - name: ...
    context:
      container: "%{ item.container }"
    cases:
      - strategy: matrix
        values:
          container: [null, {}]
```

Finally, it fixes the priority in `samples/expected_outcome.yaml` and adds a debug log line.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
