### PR TITLE
feat(suite/loader): make dir fds optional for `*at()` syscall steps

### DIFF
--- a/pkg/test/loader/schema/jsonschemas/steps/syscalls/linkAt.schema.json
+++ b/pkg/test/loader/schema/jsonschemas/steps/syscalls/linkAt.schema.json
@@ -13,10 +13,8 @@
           "type": [
             "string"
           ],
-          "$ref": "binding.schema.json",
-          "examples": [
-            "/path/to/old/dir"
-          ]
+          "default": "File descriptor referring to the current working directory (i.e: AT_FDCWD)",
+          "$ref": "binding.schema.json"
         },
         "oldPath": {
           "description": "The file path referring to the existing file that must be linked. If it is relative, it is interpreted relative to the directory referred to by 'oldDirFd'",
@@ -33,10 +31,8 @@
           "type": [
             "string"
           ],
-          "$ref": "binding.schema.json",
-          "examples": [
-            "/path/to/new/dir"
-          ]
+          "default": "File descriptor referring to the current working directory (i.e: AT_FDCWD)",
+          "$ref": "binding.schema.json"
         },
         "newPath": {
           "description": "The file path of the link that is requested to be created. If it is relative, it is interpreted relative to the directory referred to by 'newDirFd'",
@@ -62,9 +58,7 @@
         }
       },
       "required": [
-        "oldDirFd",
         "oldPath",
-        "newDirFd",
         "newPath"
       ]
     },

--- a/pkg/test/loader/schema/jsonschemas/steps/syscalls/openAt.schema.json
+++ b/pkg/test/loader/schema/jsonschemas/steps/syscalls/openAt.schema.json
@@ -13,10 +13,8 @@
           "type": [
             "string"
           ],
-          "$ref": "binding.schema.json",
-          "examples": [
-            "/path/to/dir"
-          ]
+          "default": "File descriptor referring to the current working directory (i.e: AT_FDCWD)",
+          "$ref": "binding.schema.json"
         },
         "pathname": {
           "description": "The path that must be opened. If it is relative, it is interpreted relative to the directory referred to by 'dirFd'",
@@ -52,7 +50,6 @@
         }
       },
       "required": [
-        "dirFd",
         "pathname",
         "flags"
       ]

--- a/pkg/test/loader/schema/jsonschemas/steps/syscalls/openAt2.schema.json
+++ b/pkg/test/loader/schema/jsonschemas/steps/syscalls/openAt2.schema.json
@@ -13,10 +13,8 @@
           "type": [
             "string"
           ],
-          "$ref": "binding.schema.json",
-          "examples": [
-            "/path/to/dir"
-          ]
+          "default": "File descriptor referring to the current working directory (i.e: AT_FDCWD)",
+          "$ref": "binding.schema.json"
         },
         "pathname": {
           "description": "The path that must be opened. If it is relative, it is interpreted relative to the directory referred to by 'dirFd'",
@@ -68,7 +66,6 @@
         }
       },
       "required": [
-        "dirFd",
         "pathname"
       ]
     },

--- a/pkg/test/loader/schema/jsonschemas/steps/syscalls/symLinkAt.schema.json
+++ b/pkg/test/loader/schema/jsonschemas/steps/syscalls/symLinkAt.schema.json
@@ -23,10 +23,8 @@
           "type": [
             "string"
           ],
-          "$ref": "binding.schema.json",
-          "examples": [
-            "/path/to/dir"
-          ]
+          "default": "File descriptor referring to the current working directory (i.e: AT_FDCWD)",
+          "$ref": "binding.schema.json"
         },
         "linkPath": {
           "description": "The file path of the symbolic link that is requested to be created",
@@ -41,7 +39,6 @@
       },
       "required": [
         "target",
-        "newDirFd",
         "linkPath"
       ]
     },


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our [CONTRIBUTING.md](../CONTRIBUTING.md).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note: it's really useful for the changelog!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind documentation

> /kind tests

> /kind feature

> If this PR prepares a chart release, uncomment:

> /kind chart-release

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area commands

/area pkg

> /area events

> /area chart

> /area automation

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR makes dir fd fields optional for `*at()` syscall steps. If a file descriptor is not specified (i.e.: not bound to anything), it defaults to `AT_FDCWD`. Moreover, it fixes some wrong (related) JSON schema examples.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
