### PR TITLE
fix(suite/loader): avoid YAML-encoding test's source index

### DIFF
--- a/pkg/test/loader/loader.go
+++ b/pkg/test/loader/loader.go
@@ -397,7 +397,7 @@ type Test struct {
 	// SourceIndex is the position of the test in the source from which it has been loaded. All tests generated from
 	// the same test template, shares the same source position (which is equal to the test template position in the
 	// source).
-	SourceIndex int
+	SourceIndex int `yaml:"-" mapstructure:"-"`
 }
 
 // validateNameUniqueness validates that names used for test resources and steps are unique.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our [CONTRIBUTING.md](../CONTRIBUTING.md).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note: it's really useful for the changelog!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind documentation

> /kind tests

> /kind feature

> If this PR prepares a chart release, uncomment:

> /kind chart-release

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area commands

/area pkg

> /area events

> /area chart

> /area automation

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

A test's source index doesn't need to be propagated to any child process through the tests description YAML encoding, as it is already propagated in the baggage.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
