### PR TITLE
feat(suite): add support for `verify` sub-command

### DIFF
--- a/cmd/suite/config/config.go
+++ b/cmd/suite/config/config.go
@@ -16,14 +16,13 @@
 package config
 
 import (
-	"fmt"
-	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/thediveo/enumflag/v2"
 
 	"github.com/falcosecurity/event-generator/pkg/container/builder"
+	"github.com/falcosecurity/event-generator/pkg/envvar"
 )
 
 const (
@@ -107,12 +106,12 @@ func New(suiteEnvKey, envKeysPrefix string) *Config {
 	commonConf := &Config{
 		SuiteEnvKey:           suiteEnvKey,
 		EnvKeysPrefix:         envKeysPrefix,
-		DescriptionFileEnvKey: envKeyFromFlagName(envKeysPrefix, DescriptionFileFlagName),
-		DescriptionDirEnvKey:  envKeyFromFlagName(envKeysPrefix, DescriptionDirFlagName),
-		DescriptionEnvKey:     envKeyFromFlagName(envKeysPrefix, DescriptionFlagName),
-		TestIDEnvKey:          envKeyFromFlagName(envKeysPrefix, TestIDFlagName),
-		BaggageEnvKey:         envKeyFromFlagName(envKeysPrefix, BaggageFlagName),
-		TimeoutEnvKey:         envKeyFromFlagName(envKeysPrefix, TimeoutFlagName),
+		DescriptionFileEnvKey: envvar.KeyFromFlagName(envKeysPrefix, DescriptionFileFlagName),
+		DescriptionDirEnvKey:  envvar.KeyFromFlagName(envKeysPrefix, DescriptionDirFlagName),
+		DescriptionEnvKey:     envvar.KeyFromFlagName(envKeysPrefix, DescriptionFlagName),
+		TestIDEnvKey:          envvar.KeyFromFlagName(envKeysPrefix, TestIDFlagName),
+		BaggageEnvKey:         envvar.KeyFromFlagName(envKeysPrefix, BaggageFlagName),
+		TimeoutEnvKey:         envvar.KeyFromFlagName(envKeysPrefix, TimeoutFlagName),
 	}
 	return commonConf
 }
@@ -158,11 +157,4 @@ func (c *Config) InitCommandFlags(cmd *cobra.Command) {
 			"logging purposes and to potentially generate the child process/container baggage")
 	_ = flags.MarkHidden(TestIDFlagName)
 	_ = flags.MarkHidden(BaggageFlagName)
-}
-
-// envKeyFromFlagName converts the provided flag name into the corresponding environment variable key.
-func envKeyFromFlagName(envKeysPrefix, flagName string) string {
-	s := fmt.Sprintf("%s_%s", envKeysPrefix, strings.ToUpper(flagName))
-	s = strings.ToUpper(s)
-	return strings.ReplaceAll(s, "-", "_")
 }

--- a/cmd/suite/suite.go
+++ b/cmd/suite/suite.go
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-// Copyright (C) 2025 The Falco Authors
+// Copyright (C) 2026 The Falco Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import (
 	"github.com/falcosecurity/event-generator/cmd/suite/explain"
 	"github.com/falcosecurity/event-generator/cmd/suite/run"
 	"github.com/falcosecurity/event-generator/cmd/suite/test"
+	"github.com/falcosecurity/event-generator/cmd/suite/verify"
 )
 
 // New creates a new suite command.
@@ -38,8 +39,10 @@ func New(suiteEnvKey, envKeysPrefix string) *cobra.Command {
 	runCmd := run.New(commonConf)
 	testCmd := test.New(commonConf, false).Command
 	explainCmd := explain.New().Command
+	verifyCmd := verify.New(suiteEnvKey, envKeysPrefix).Command
 	c.AddCommand(runCmd)
 	c.AddCommand(testCmd)
 	c.AddCommand(explainCmd)
+	c.AddCommand(verifyCmd)
 	return c
 }

--- a/cmd/suite/test/test.go
+++ b/cmd/suite/test/test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/falcosecurity/event-generator/cmd/suite/config"
 	"github.com/falcosecurity/event-generator/pkg/baggage"
 	containerbuilder "github.com/falcosecurity/event-generator/pkg/container/builder"
+	"github.com/falcosecurity/event-generator/pkg/envvar"
 	processbuilder "github.com/falcosecurity/event-generator/pkg/process/builder"
 	"github.com/falcosecurity/event-generator/pkg/test"
 	testbuilder "github.com/falcosecurity/event-generator/pkg/test/builder"
@@ -143,13 +144,6 @@ func (cw *CommandWrapper) initFlags(c *cobra.Command) {
 		"report-format", "The format of the test suites report; can be 'text', 'json' or 'yaml'")
 }
 
-// envKeyFromFlagName converts the provided flag name into the corresponding environment variable key.
-func envKeyFromFlagName(envKeysPrefix, flagName string) string {
-	s := fmt.Sprintf("%s_%s", envKeysPrefix, strings.ToUpper(flagName))
-	s = strings.ToUpper(s)
-	return strings.ReplaceAll(s, "-", "_")
-}
-
 // run runs the provided command with the provided arguments.
 func (cw *CommandWrapper) run(cmd *cobra.Command, _ []string) {
 	ctx := cmd.Context()
@@ -179,7 +173,7 @@ func (cw *CommandWrapper) run(cmd *cobra.Command, _ []string) {
 	isRootProcess := cw.TestID == ""
 	verifyExpectedOutcome := isRootProcess && !cw.skipOutcomeVerification
 
-	reservedEnvKeyPrefixes := []string{envKeyFromFlagName(cw.EnvKeysPrefix, "")}
+	reservedEnvKeyPrefixes := []string{envvar.KeyFromFlagName(cw.EnvKeysPrefix, "")}
 	reservedEnvKeys := []string{cw.SuiteEnvKey}
 	testSuites, err := loadTestSuites(logger, !verifyExpectedOutcome, cw.TestsDescriptionFiles, cw.TestsDescriptionDirs,
 		cw.TestsDescription, reservedEnvKeyPrefixes, reservedEnvKeys)
@@ -570,7 +564,7 @@ func sendTestReport(ctx context.Context, reportCh chan<- *tester.Report, report 
 func (cw *CommandWrapper) buildRunnerEnviron(cmd *cobra.Command) []string {
 	environ := os.Environ()
 	environ = cw.appendFlags(environ, cmd.PersistentFlags(), cmd.Flags())
-	environ = append(environ, fmt.Sprintf("%s=1", cw.SuiteEnvKey))
+	environ = append(environ, envvar.EnvVar(cw.SuiteEnvKey, "1"))
 	return environ
 }
 
@@ -578,8 +572,8 @@ func (cw *CommandWrapper) buildRunnerEnviron(cmd *cobra.Command) []string {
 // append function.
 func (cw *CommandWrapper) appendFlags(environ []string, flagSets ...*pflag.FlagSet) []string {
 	appendFlag := func(flag *pflag.Flag) {
-		keyName := envKeyFromFlagName(cw.EnvKeysPrefix, flag.Name)
-		environ = append(environ, fmt.Sprintf("%s=%s", keyName, flag.Value.String()))
+		envKey := envvar.KeyFromFlagName(cw.EnvKeysPrefix, flag.Name)
+		environ = append(environ, envvar.EnvVar(envKey, flag.Value.String()))
 	}
 	for _, flagSet := range flagSets {
 		flagSet.VisitAll(appendFlag)

--- a/cmd/suite/test/test.go
+++ b/cmd/suite/test/test.go
@@ -173,9 +173,10 @@ func (cw *CommandWrapper) run(cmd *cobra.Command, _ []string) {
 	isRootProcess := cw.TestID == ""
 	verifyExpectedOutcome := isRootProcess && !cw.skipOutcomeVerification
 
+	// Note: keep the following in sync with the corresponding code in "verify" package.
 	reservedEnvKeyPrefixes := []string{envvar.KeyFromFlagName(cw.EnvKeysPrefix, "")}
 	reservedEnvKeys := []string{cw.SuiteEnvKey}
-	testSuites, err := loadTestSuites(logger, !verifyExpectedOutcome, cw.TestsDescriptionFiles, cw.TestsDescriptionDirs,
+	testSuites, err := LoadSuites(logger, !verifyExpectedOutcome, cw.TestsDescriptionFiles, cw.TestsDescriptionDirs,
 		cw.TestsDescription, reservedEnvKeyPrefixes, reservedEnvKeys)
 	if err != nil {
 		if noRuleNameErr := (*suite.NoRuleNameError)(nil); errors.As(err, &noRuleNameErr) {
@@ -353,16 +354,15 @@ func formatTestCase(testCase loader.TestCase) string {
 	return s
 }
 
-// loadTestSuites loads the test suites from a different source, depending on the content of the provided values:
+// LoadSuites loads the test suites from a different source, depending on the content of the provided values:
 //   - if the provided descriptionFilePaths or descriptionDirPaths are not empty, the test suites are loaded both from
 //     the specified files (if any) and from the YAML files (if any) in the specified directories (if any);
 //   - if the provided description is not empty, the test suites are loaded from its content;
 //   - otherwise, they are loaded from standard input.
 //
 // The parameter canLoadTestsWithNoRuleName is used to allow/disallow loading of tests with absent or empty rule names.
-func loadTestSuites(logger logr.Logger, canLoadTestsWithNoRuleName bool, descriptionFilePaths,
-	descriptionDirPaths []string, description string,
-	reservedEnvKeyPrefixes, reservedEnvKeys []string) ([]*suite.Suite, error) {
+func LoadSuites(logger logr.Logger, canLoadTestsWithNoRuleName bool, descriptionFilePaths, descriptionDirPaths []string,
+	description string, reservedEnvKeyPrefixes, reservedEnvKeys []string) ([]*suite.Suite, error) {
 	descLoader := loader.New(reservedEnvKeyPrefixes, reservedEnvKeys)
 	testSuiteLoader := suiteloader.New(descLoader, canLoadTestsWithNoRuleName)
 

--- a/cmd/suite/verify/doc.go
+++ b/cmd/suite/verify/doc.go
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package verify provides the implementation of the "verify" command. This command lets users verify the tests YAML
+// description.
+package verify

--- a/cmd/suite/verify/verify.go
+++ b/cmd/suite/verify/verify.go
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package verify
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/go-logr/logr"
+	"github.com/spf13/cobra"
+
+	"github.com/falcosecurity/event-generator/cmd/suite/config"
+	"github.com/falcosecurity/event-generator/cmd/suite/test"
+	"github.com/falcosecurity/event-generator/pkg/envvar"
+)
+
+const (
+	longDescriptionPrefaceTemplate = `%s.
+It is possible to provide the YAML description in multiple ways. The order of evaluation is the following:
+1) If --%s=<file_path> and/or --%s=<dir_path> flags are/is provided, it is read from the file(s) at <file_path> and/or contained in <dir_path>
+2) If the --%s=<description> flag is provided, it is read from the <description> string
+3) Otherwise, it is read from standard input`
+	longDescriptionHeading = "Verify the test(s) YAML description"
+)
+
+var (
+	longDescription = fmt.Sprintf(longDescriptionPrefaceTemplate, longDescriptionHeading,
+		config.DescriptionFileFlagName, config.DescriptionDirFlagName, config.DescriptionFlagName)
+)
+
+// CommandWrapper wraps the command and stores the associated flag values.
+type CommandWrapper struct {
+	Command       *cobra.Command
+	envKeysPrefix string
+	suiteEnvKey   string
+
+	// Flags
+	//
+	// testsDescriptionFiles is the list of pathnames of files containing the YAML tests descriptions. If
+	// testsDescription is provided, this is empty.
+	testsDescriptionFiles []string
+	// testsDescriptionDirs is the list of pathnames of directories containing the YAML tests description files. If
+	// testsDescription is provided, this is empty.
+	testsDescriptionDirs []string
+	// testsDescription is the YAML tests description. If testsDescriptionFiles or testsDescriptionDirs are provided,
+	// this is empty.
+	testsDescription string
+}
+
+// New creates a new verify command.
+func New(suiteEnvKey, envKeysPrefix string) *CommandWrapper {
+	cw := &CommandWrapper{envKeysPrefix: envKeysPrefix, suiteEnvKey: suiteEnvKey}
+	c := &cobra.Command{
+		Use:               "verify",
+		Short:             longDescriptionHeading,
+		Long:              longDescription,
+		DisableAutoGenTag: true,
+		Run:               cw.run,
+	}
+	cw.Command = c
+	cw.initCommandFlags()
+	return cw
+}
+
+// initCommandFlags initializes the command's flags.
+func (cw *CommandWrapper) initCommandFlags() {
+	cmd := cw.Command
+	flags := cmd.Flags()
+
+	flags.StringSliceVarP(&cw.testsDescriptionFiles, config.DescriptionFileFlagName, "f", nil,
+		"The pathnames of tests description YAML files specifying the tests to be verified. Multiple pathnames can be "+
+			"specified as a comma-separated list. The flag can be specified multiple times. Pathnames are evaluated "+
+			"in order of appearance")
+	flags.StringSliceVarP(&cw.testsDescriptionDirs, config.DescriptionDirFlagName, "d", nil,
+		"The pathnames of directories containing tests description YAML files specifying the tests to be verified. "+
+			"Sub-directories of the provided pathnames are not recursively loaded. Only files with YAML extensions "+
+			"are loaded. Multiple pathnames can be specified as a comma-separated list. The flag can be specified "+
+			"multiple times. Pathnames are evaluated in order of appearance")
+	flags.StringVar(&cw.testsDescription, config.DescriptionFlagName, "",
+		"The YAML-formatted tests description string specifying the tests to be verified")
+	cmd.MarkFlagsMutuallyExclusive(config.DescriptionFileFlagName, config.DescriptionFlagName)
+	cmd.MarkFlagsMutuallyExclusive(config.DescriptionDirFlagName, config.DescriptionFlagName)
+}
+
+func (cw *CommandWrapper) run(cmd *cobra.Command, _ []string) {
+	ctx := cmd.Context()
+	logger, err := logr.FromContext(ctx)
+	if err != nil {
+		panic(fmt.Sprintf("logger unconfigured: %v", err))
+	}
+
+	logger = logger.WithName("main")
+
+	// Note: keep the following in sync with the corresponding code in "test" package.
+	reservedEnvKeyPrefixes := []string{envvar.KeyFromFlagName(cw.envKeysPrefix, "")}
+	reservedEnvKeys := []string{cw.suiteEnvKey}
+	if _, err := test.LoadSuites(logger, false, cw.testsDescriptionFiles, cw.testsDescriptionDirs,
+		cw.testsDescription, reservedEnvKeyPrefixes, reservedEnvKeys); err != nil {
+		// Do not use the logger here, as it will mess the already-formatted error message.
+		_, _ = fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}

--- a/pkg/envvar/doc.go
+++ b/pkg/envvar/doc.go
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package envvar provides some helpers for working with environment variables.
+package envvar

--- a/pkg/envvar/envvar.go
+++ b/pkg/envvar/envvar.go
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package envvar
+
+import (
+	"fmt"
+	"strings"
+)
+
+// KeyFromFlagName converts the provided flag name into the corresponding environment variable key.
+func KeyFromFlagName(envKeysPrefix, flagName string) string {
+	s := fmt.Sprintf("%s_%s", envKeysPrefix, strings.ToUpper(flagName))
+	s = strings.ToUpper(s)
+	return strings.ReplaceAll(s, "-", "_")
+}
+
+// EnvVar creates an environment variable string in the form "<key>=<value>".
+func EnvVar(key, value string) string {
+	return fmt.Sprintf("%s=%s", key, value)
+}
+
+// KeyAndVal returns the key and the value of the provided environment variable. The extraction is performed by
+// splitting at the first "=" sign. The boolean indicates if the extraction succeeded or failed (this can happen in case
+// of malformed input).
+func KeyAndVal(envVar string) (key, value string, success bool) {
+	key, value, success = strings.Cut(envVar, "=")
+	return
+}

--- a/pkg/test/resource/builder/builder.go
+++ b/pkg/test/resource/builder/builder.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/go-logr/logr"
 
+	"github.com/falcosecurity/event-generator/pkg/envvar"
 	"github.com/falcosecurity/event-generator/pkg/process"
 	"github.com/falcosecurity/event-generator/pkg/test/loader"
 	"github.com/falcosecurity/event-generator/pkg/test/resource"
@@ -185,7 +186,7 @@ func buildProcEnv(userEnv map[string]string) []string {
 
 	// Add the user-provided environment variable.
 	for key, value := range userEnv {
-		env = append(env, fmt.Sprintf("%s=%s", key, value))
+		env = append(env, envvar.EnvVar(key, value))
 	}
 	return env
 }

--- a/pkg/test/runner/host/host.go
+++ b/pkg/test/runner/host/host.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/falcosecurity/event-generator/pkg/baggage"
 	"github.com/falcosecurity/event-generator/pkg/container"
+	"github.com/falcosecurity/event-generator/pkg/envvar"
 	"github.com/falcosecurity/event-generator/pkg/process"
 	"github.com/falcosecurity/event-generator/pkg/test"
 	"github.com/falcosecurity/event-generator/pkg/test/loader"
@@ -216,11 +217,11 @@ func (r *hostRunner) buildEnv(testID string, userEnv map[string]string, testDesc
 	if isLastProcess {
 		testID = r.stripTestIDIgnorePrefix(testID)
 	}
-	env = append(env, buildEnvVar(r.TestIDEnvKey, testID))
+	env = append(env, envvar.EnvVar(r.TestIDEnvKey, testID))
 
 	// Add the user-provided environment variables.
 	for key, value := range userEnv {
-		env = append(env, fmt.Sprintf("%s=%s", key, value))
+		env = append(env, envvar.EnvVar(key, value))
 	}
 
 	// Add the test description environment variable building it from the serialized test description.
@@ -228,18 +229,18 @@ func (r *hostRunner) buildEnv(testID string, userEnv map[string]string, testDesc
 	if err != nil {
 		return nil, fmt.Errorf("error serializing new test description: %w", err)
 	}
-	env = append(env, buildEnvVar(r.TestDescriptionEnvKey, description))
+	env = append(env, envvar.EnvVar(r.TestDescriptionEnvKey, description))
 
 	// Add the baggage environment variable.
 	baggageValue, err := marshalBaggage(bag)
 	if err != nil {
 		return nil, fmt.Errorf("error serializing baggage: %w", err)
 	}
-	env = append(env, buildEnvVar(r.BaggageEnvKey, baggageValue))
+	env = append(env, envvar.EnvVar(r.BaggageEnvKey, baggageValue))
 
 	// Add the process environment, but exclude the environment variables that we overrode.
 	for _, envVar := range r.Environ {
-		if envKey, _, found := strings.Cut(envVar, "="); !found || !r.mustOverrideEnv(envKey) {
+		if envKey, _, found := envvar.KeyAndVal(envVar); !found || !r.mustOverrideEnv(envKey) {
 			env = append(env, envVar)
 		}
 	}
@@ -256,11 +257,6 @@ func marshalTestDescription(testDesc *loader.Test) (string, error) {
 	}
 
 	return sb.String(), nil
-}
-
-// buildEnvVar creates an environment variable string in the form "<envKey>=<envValue>".
-func buildEnvVar(envKey, envValue string) string {
-	return fmt.Sprintf("%s=%s", envKey, envValue)
 }
 
 // stripTestIDIgnorePrefix strips the ignore prefix from the provided test ID and returns it. The returned value is

--- a/pkg/test/tester/tester/tester.go
+++ b/pkg/test/tester/tester/tester.go
@@ -24,6 +24,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/falcosecurity/event-generator/pkg/alert"
+	"github.com/falcosecurity/event-generator/pkg/envvar"
 	"github.com/falcosecurity/event-generator/pkg/test/loader"
 	"github.com/falcosecurity/event-generator/pkg/test/tester"
 )
@@ -45,7 +46,7 @@ var _ tester.Tester = (*testerImpl)(nil)
 
 // New creates a new tester.
 func New(alertRetriever alert.Retriever, testIDEnvKey, testIDIgnorePrefix string) tester.Tester {
-	testIDEnvVarPrefix := testIDEnvKey + "="
+	testIDEnvVarPrefix := envvar.EnvVar(testIDEnvKey, "")
 	testIDEnvVarPrefixLen := len(testIDEnvVarPrefix)
 	t := &testerImpl{
 		alertRetriever:        alertRetriever,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our [CONTRIBUTING.md](../CONTRIBUTING.md).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note: it's really useful for the changelog!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind documentation

> /kind tests

/kind feature

> If this PR prepares a chart release, uncomment:

> /kind chart-release

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area commands

/area pkg

> /area events

> /area chart

> /area automation

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR adds a new `suite verify` sub-command that allows to verify tests YAML description that could come from multiple sources. The order and the way sources are evaluated is identical to the one the `suite test` command offers. If any error is encountered while validating any YAML description, the reason is printed to stderr, and the exit code is set to 1; otherwise, nothing is printed and the exit code 0 is set.

Moreover, this PR adds a small `envvar` package for handling environment variables.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
