### PR TITLE
feat(cmd/suite/render): add support for `--count` option

### DIFF
--- a/cmd/suite/render/render.go
+++ b/cmd/suite/render/render.go
@@ -63,6 +63,8 @@ type CommandWrapper struct {
 	// testsDescription is the YAML tests description. If testsDescriptionFiles or testsDescriptionDirs are provided,
 	// this is empty.
 	testsDescription string
+	// printTestsCount indicates if the user just want the tool to out-put the total number of tests.
+	printTestsCount bool
 }
 
 // New creates a new render command.
@@ -98,6 +100,7 @@ func (cw *CommandWrapper) initCommandFlags() {
 		"The YAML-formatted tests description string specifying the tests to be rendered")
 	cmd.MarkFlagsMutuallyExclusive(config.DescriptionFileFlagName, config.DescriptionFlagName)
 	cmd.MarkFlagsMutuallyExclusive(config.DescriptionDirFlagName, config.DescriptionFlagName)
+	flags.BoolVar(&cw.printTestsCount, "count", false, "Prints the total number of tests and exit")
 }
 
 func (cw *CommandWrapper) run(cmd *cobra.Command, _ []string) {
@@ -112,16 +115,26 @@ func (cw *CommandWrapper) run(cmd *cobra.Command, _ []string) {
 	// Note: keep the following in sync with the corresponding code in "test" package.
 	reservedEnvKeyPrefixes := []string{envvar.KeyFromFlagName(cw.envKeysPrefix, "")}
 	reservedEnvKeys := []string{cw.suiteEnvKey}
-	testDescs, err := loadTests(logger, cw.testsDescriptionFiles, cw.testsDescriptionDirs, cw.testsDescription,
+	testsDescs, err := loadTests(logger, cw.testsDescriptionFiles, cw.testsDescriptionDirs, cw.testsDescription,
 		reservedEnvKeyPrefixes, reservedEnvKeys)
 	if err != nil {
 		logger.Error(err, "Error loading tests")
 		os.Exit(1)
 	}
 
+	// If the user requested the tests count, just print it and return.
+	if cw.printTestsCount {
+		testsCount := 0
+		for _, testDesc := range testsDescs {
+			testsCount += len(testDesc.desc.Tests)
+		}
+		fmt.Println(testsCount)
+		return
+	}
+
 	w := os.Stdout
-	for _, testDesc := range testDescs {
-		source := testDesc.source
+	for _, testsDesc := range testsDescs {
+		source := testsDesc.source
 		logger := logger.WithValues("source", source)
 		header := fmt.Sprintf("---\n# source: %s\n", source)
 		if _, err := w.WriteString(header); err != nil {
@@ -129,7 +142,7 @@ func (cw *CommandWrapper) run(cmd *cobra.Command, _ []string) {
 			os.Exit(1)
 		}
 
-		if err := testDesc.desc.Write(w); err != nil {
+		if err := testsDesc.desc.Write(w); err != nil {
 			logger.Error(err, "Error writing tests description")
 			os.Exit(1)
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our [CONTRIBUTING.md](../CONTRIBUTING.md).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note: it's really useful for the changelog!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

> /kind bug

> /kind cleanup

> /kind documentation

> /kind tests

/kind feature

> If this PR prepares a chart release, uncomment:

> /kind chart-release

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area commands

> /area pkg

> /area events

> /area chart

> /area automation

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR adds support for `--count` option returning the total number of parsed tests.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
