### PR TITLE
feat(suite): add support for constraining execution by architecture

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -107,7 +107,7 @@ runs:
         BIN: ${{ steps.build.outputs.bin }}
         DIR: ${{ steps.resolve.outputs.dir }}
       run: |
-        COUNT="$("$BIN" suite render --description-dir "$DIR" --count)"
+        COUNT="$("$BIN" suite render --description-dir "$DIR" --count --eligible)"
         echo "count=${COUNT}" >> "$GITHUB_OUTPUT"
         echo "Expected passing tests across ${DIR}: ${COUNT}"
 

--- a/cmd/suite/render/render.go
+++ b/cmd/suite/render/render.go
@@ -19,12 +19,14 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/go-logr/logr"
 	"github.com/spf13/cobra"
 
 	"github.com/falcosecurity/event-generator/cmd/suite/config"
+	"github.com/falcosecurity/event-generator/cmd/suite/test"
 	"github.com/falcosecurity/event-generator/pkg/envvar"
 	"github.com/falcosecurity/event-generator/pkg/test/loader"
 )
@@ -63,7 +65,10 @@ type CommandWrapper struct {
 	// testsDescription is the YAML tests description. If testsDescriptionFiles or testsDescriptionDirs are provided,
 	// this is empty.
 	testsDescription string
-	// printTestsCount indicates if the user just want the tool to out-put the total number of tests.
+	// onlyEligibleTests indicates if the user want the tool just to account for eligible tests.
+	onlyEligibleTests bool
+	// printTestsCount indicates if the user want the tool just to out-put the total number of tests. If
+	// onlyEligibleTests is true, only eligible tests are taken into account.
 	printTestsCount bool
 }
 
@@ -100,6 +105,7 @@ func (cw *CommandWrapper) initCommandFlags() {
 		"The YAML-formatted tests description string specifying the tests to be rendered")
 	cmd.MarkFlagsMutuallyExclusive(config.DescriptionFileFlagName, config.DescriptionFlagName)
 	cmd.MarkFlagsMutuallyExclusive(config.DescriptionDirFlagName, config.DescriptionFlagName)
+	flags.BoolVar(&cw.onlyEligibleTests, "eligible", false, "Only take into account eligible tests")
 	flags.BoolVar(&cw.printTestsCount, "count", false, "Prints the total number of tests and exit")
 }
 
@@ -125,8 +131,20 @@ func (cw *CommandWrapper) run(cmd *cobra.Command, _ []string) {
 	// If the user requested the tests count, just print it and return.
 	if cw.printTestsCount {
 		testsCount := 0
-		for _, testDesc := range testsDescs {
-			testsCount += len(testDesc.desc.Tests)
+		for _, testsDesc := range testsDescs {
+			tests := testsDesc.desc.Tests
+			// Account for all tests if the user didn't request to only take into account eligible ones.
+			if !cw.onlyEligibleTests {
+				testsCount += len(testsDesc.desc.Tests)
+				continue
+			}
+
+			// Only account for eligible tests.
+			for testIdx := range tests {
+				if isEligible, _ := test.IsTestEligible(&tests[testIdx]); isEligible {
+					testsCount++
+				}
+			}
 		}
 		fmt.Println(testsCount)
 		return
@@ -134,15 +152,31 @@ func (cw *CommandWrapper) run(cmd *cobra.Command, _ []string) {
 
 	w := os.Stdout
 	for _, testsDesc := range testsDescs {
-		source := testsDesc.source
+		source, desc := testsDesc.source, testsDesc.desc
 		logger := logger.WithValues("source", source)
+
+		if cw.onlyEligibleTests {
+			// It's fine to modify tests in-place, as after printing the description we will not use it anymore.
+			desc.Tests = slices.DeleteFunc(desc.Tests, func(t loader.Test) bool {
+				isEligible, _ := test.IsTestEligible(&t)
+				return !isEligible
+			})
+		}
+
+		// Skip sources with no tests. This can only happen if cw.onlyEligibleTests is true.
+		if len(desc.Tests) == 0 {
+			logger.Info("Skipped source with no eligible tests")
+			continue
+		}
+
+		// Write header and tests description.
 		header := fmt.Sprintf("---\n# source: %s\n", source)
 		if _, err := w.WriteString(header); err != nil {
 			logger.Error(err, "Error writing tests description header")
 			os.Exit(1)
 		}
 
-		if err := testsDesc.desc.Write(w); err != nil {
+		if err := desc.Write(w); err != nil {
 			logger.Error(err, "Error writing tests description")
 			os.Exit(1)
 		}

--- a/cmd/suite/test/test.go
+++ b/cmd/suite/test/test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -187,6 +188,19 @@ func (cw *CommandWrapper) run(cmd *cobra.Command, _ []string) {
 		abort()
 	}
 
+	// Calculate the number of tests that are eligible to be run. The execution is terminated in case of zero eligible
+	// tests. It is not expected to have zero eligible tests in a process other than the root one.
+	eligibleTestsNum := getEligibleTestsNum(testSuites)
+	if eligibleTestsNum == 0 {
+		if !isRootProcess {
+			logger.Error(fmt.Errorf("no eligible tests to run"), "Error evaluating tests")
+			abort()
+		}
+		logger.Info("No eligible tests to run. Quitting")
+		cancel()
+		return
+	}
+
 	runnerBuilder, err := cw.createRunnerBuilder()
 	if err != nil {
 		logger.Error(err, "Error creating runner builder")
@@ -234,7 +248,7 @@ func (cw *CommandWrapper) run(cmd *cobra.Command, _ []string) {
 			defer waitGroup.Done()
 			defer close(reportCollectionCompletedCh)
 			defer close(reportCh)
-			expectedReportsNum := getTestsNum(testSuites)
+			expectedReportsNum := eligibleTestsNum
 			testSuitesReports, err := collectTestSuitesReports(ctx, expectedReportsNum, reportCh)
 			if err != nil {
 				return
@@ -285,8 +299,18 @@ func (cw *CommandWrapper) run(cmd *cobra.Command, _ []string) {
 		testSuiteName := testSuite.RuleName
 		logger := baseLogger.WithValues("testSuiteName", testSuiteName)
 		logInfoIf(logger, isRootProcess, "Starting test suite execution...")
-		// Run all tests in the test suite.
+
+		atLeastOneEligible := false
+
+		// Run all eligible tests in the test suite.
 		for _, testInfo := range testSuite.TestsInfo {
+			if isEligible, reason := IsTestEligible(testInfo.Test); !isEligible {
+				logInfoIf(logger, isRootProcess, "Skipped non-eligible test", "reason", reason)
+				continue
+			}
+
+			atLeastOneEligible = true
+
 			// Wrap execution in a function to allow deferring sendEmptyTestReportIfPanicOrFailure.
 			func() {
 				testExecutionFailed := false
@@ -307,6 +331,12 @@ func (cw *CommandWrapper) run(cmd *cobra.Command, _ []string) {
 				}
 			}()
 		}
+
+		if !atLeastOneEligible {
+			logInfoIf(logger, isRootProcess, "No eligible tests to run. Skipping test suite")
+			continue
+		}
+
 		logInfoIf(logger, isRootProcess, "Test suite execution completed")
 	}
 
@@ -444,6 +474,52 @@ func loadTestsFromDescriptionFile(logger logr.Logger, testSuiteLoader suite.Load
 	return testSuiteLoader.Load(descriptionFile)
 }
 
+// getEligibleTestsNum returns the total number of eligible tests contained in the provided test suites.
+func getEligibleTestsNum(testSuites []*suite.Suite) int {
+	count := 0
+	for _, testSuite := range testSuites {
+		for _, testInfo := range testSuite.TestsInfo {
+			if isEligible, _ := IsTestEligible(testInfo.Test); isEligible {
+				count++
+			}
+		}
+	}
+	return count
+}
+
+// IsTestEligible verifies if the provided test is eligible to be run and returns a boolean indicating it. If the test
+// is not eligible, it also returns a non-empty reason explaining why it is not; reason is empty otherwise.
+func IsTestEligible(testDesc *loader.Test) (isEligible bool, reason string) {
+	runIf := testDesc.RunIf
+	if runIf == nil {
+		return true, ""
+	}
+
+	archCond := runIf.Arch
+	if archCond == nil {
+		return true, ""
+	}
+
+	const currentArch = runtime.GOARCH
+	archCondOp := archCond.Op
+	switch archCondOp {
+	case loader.StringCondOpEqual:
+		val := archCond.Val.(string)
+		if val == currentArch {
+			return true, ""
+		}
+		return false, fmt.Sprintf("%s (cond arch) != %s (current arch)", val, currentArch)
+	case loader.StringCondOpNotEqual:
+		val := archCond.Val.(string)
+		if val != currentArch {
+			return true, ""
+		}
+		return false, fmt.Sprintf("%s (cond arch) == %s (current arch)", val, currentArch)
+	default:
+		panic(fmt.Sprintf("unsupported string condition operator for host architecture %v", archCondOp))
+	}
+}
+
 // createRunnerBuilder creates a new runner builder.
 func (cw *CommandWrapper) createRunnerBuilder() (runner.Builder, error) {
 	resourceProcessBuilder := processbuilder.New()
@@ -487,15 +563,6 @@ func (cw *CommandWrapper) createTester(logger logr.Logger) (tester.Tester, error
 
 	t := testerimpl.New(httpRetriever, cw.TestIDEnvKey, testIDIgnorePrefix)
 	return t, nil
-}
-
-// getTestsNum returns the total number of tests contained in the provided test suites.
-func getTestsNum(testSuites []*suite.Suite) int {
-	count := 0
-	for _, testSuite := range testSuites {
-		count += len(testSuite.TestsInfo)
-	}
-	return count
 }
 
 // collectTestSuitesReports collects test reports for all test suites from the provided report channel and returns a
@@ -582,9 +649,10 @@ func (cw *CommandWrapper) appendFlags(environ []string, flagSets ...*pflag.FlagS
 }
 
 // logInfoIf outputs to the provided logger the provided informational message only if the provided condition is true.
-func logInfoIf(logger logr.Logger, cond bool, msg string) {
+// The provided keysAndValues are passed as is to the logger.
+func logInfoIf(logger logr.Logger, cond bool, msg string, keysAndValues ...any) {
 	if cond {
-		logger.Info(msg)
+		logger.Info(msg, keysAndValues...)
 	}
 }
 

--- a/pkg/test/loader/loader.go
+++ b/pkg/test/loader/loader.go
@@ -69,7 +69,9 @@ func (l *Loader) Load(r io.Reader) (*Description, error) {
 
 	// Decode generic description into actual Description structure.
 	desc := &Description{}
-	if err := decode(rawDesc, desc, decodeTestRunnerType, decodeTestResource, decodeTestStep); err != nil {
+	decodeHooks := []mapstructure.DecodeHookFunc{decodeTestRunnerType, decodeTestResource, decodeTestStep,
+		decodeStringCond}
+	if err := decode(rawDesc, desc, decodeHooks...); err != nil {
 		return nil, fmt.Errorf("error decoding description: %w", err)
 	}
 
@@ -293,7 +295,7 @@ func getFieldBindings(containingArgName string, args map[string]any) []*TestStep
 
 // decodeTestStepType is a mapstructure.DecodeHookFunc allowing to unmarshal a TestStepType.
 func decodeTestStepType(fromType, toType reflect.Type, from any) (any, error) {
-	if fromType.Kind() != reflect.Map || toType != reflect.TypeOf(TestStepType("")) {
+	if fromType.Kind() != reflect.String || toType != reflect.TypeOf(TestStepType("")) {
 		return from, nil
 	}
 
@@ -336,6 +338,51 @@ func decodeTestStepSyscallName(fromType, toType reflect.Type, from any) (any, er
 	}
 }
 
+// decodeStringCond is a mapstructure.DecodeHookFunc allowing to unmarshal a StringCond.
+func decodeStringCond(fromType, toType reflect.Type, from any) (any, error) {
+	if fromType.Kind() != reflect.Map || toType != reflect.TypeOf(StringCond{}) {
+		return from, nil
+	}
+
+	strCond := &StringCond{}
+	if err := decode(from, strCond, decodeStringCondOp); err != nil {
+		return nil, fmt.Errorf("error decoding string condition: %w", err)
+	}
+
+	decodedOp := strCond.Op
+	// Make sure to keep Test.validateRunIf in sync if val starts to store something other than a string.
+	var val any
+	switch decodedOp {
+	case StringCondOpEqual, StringCondOpNotEqual:
+		rawVal, ok := from.(map[string]any)["val"]
+		if !ok {
+			return nil, fmt.Errorf("error decoding string condition: 'val' not present")
+		}
+		if val, ok = rawVal.(string); !ok {
+			return nil, fmt.Errorf("error decoding string condition val: expected a string value, got %T", rawVal)
+		}
+	default:
+		return nil, fmt.Errorf("unknown string condition operator %q", decodedOp)
+	}
+
+	strCond.Val = val
+	return strCond, nil
+}
+
+// decodeStringCondOp is a mapstructure.DecodeHookFunc allowing to unmarshal a StringCondOp.
+func decodeStringCondOp(fromType, toType reflect.Type, from any) (any, error) {
+	if fromType.Kind() != reflect.String || toType != reflect.TypeOf(StringCondOp("")) {
+		return from, nil
+	}
+
+	switch op := StringCondOp(from.(string)); op {
+	case StringCondOpEqual, StringCondOpNotEqual:
+		return op, nil
+	default:
+		return nil, fmt.Errorf("unknown string condition operator %q", op)
+	}
+}
+
 // Description contains the description of the tests.
 type Description struct {
 	Tests []Test `yaml:"tests" mapstructure:"tests"`
@@ -360,6 +407,11 @@ func (c *Description) validate(reservedEnvKeyPrefixes, reservedEnvKeys []string)
 				testIndex, err)
 		}
 
+		if err := test.validateRunIf(); err != nil {
+			return fmt.Errorf("error validating 'run if' conditions for test %q (index: %d): %w", test.Name,
+				testIndex, err)
+		}
+
 		if err := test.validateContext(reservedEnvKeyPrefixes, reservedEnvKeys); err != nil {
 			return fmt.Errorf("error validating test context: %w", err)
 		}
@@ -381,6 +433,7 @@ type Test struct {
 	Rule            *string              `yaml:"rule,omitempty" mapstructure:"rule"`
 	Name            string               `yaml:"name" mapstructure:"name"`
 	Description     *string              `yaml:"description,omitempty" mapstructure:"description"`
+	RunIf           *RunIfSpec           `yaml:"runIf,omitempty" mapstructure:"runIf"`
 	Runner          TestRunnerType       `yaml:"runner" mapstructure:"runner"`
 	Context         *TestContext         `yaml:"context,omitempty" mapstructure:"context"`
 	BeforeScript    *string              `yaml:"before,omitempty" mapstructure:"before"`
@@ -399,6 +452,29 @@ type Test struct {
 	// source).
 	SourceIndex int `yaml:"-" mapstructure:"-"`
 }
+
+// RunIfSpec specifies conditions under which the current Test should be run. If multiple conditions are specified,
+// their logical outcomes are ANDed.
+type RunIfSpec struct {
+	Arch *StringCond `yaml:"arch,omitempty" mapstructure:"arch"`
+}
+
+// StringCond is a string condition comparing the subject with Val, following the semantics of the operator Op. Val can
+// be of whatever type the operator allows. The subject is implicitly determined by the context.
+type StringCond struct {
+	Op  StringCondOp `yaml:"op" mapstructure:"op"`
+	Val any          `yaml:"val" mapstructure:"-"`
+}
+
+// StringCondOp is the operator of a string condition.
+type StringCondOp string
+
+const (
+	// StringCondOpEqual specifies that the subject must be equal to the provided value.
+	StringCondOpEqual StringCondOp = "eq"
+	// StringCondOpNotEqual specifies that the subject must not be equal to the provided value.
+	StringCondOpNotEqual StringCondOp = "ne"
+)
 
 // validateNameUniqueness validates that names used for test resources and steps are unique.
 func (t *Test) validateNameUniqueness() error {
@@ -441,6 +517,27 @@ func (t *Test) validateNameUniqueness() error {
 	}
 
 	return nil
+}
+
+func (t *Test) validateRunIf() error {
+	runIf := t.RunIf
+	if runIf == nil {
+		return nil
+	}
+
+	arch := runIf.Arch
+	if arch == nil {
+		return nil
+	}
+
+	// The current loader logic makes sure the architecture value is a string (see decodeStringCond).
+	archVal := arch.Val.(string)
+	switch archVal {
+	case "amd64", "arm64":
+		return nil
+	default:
+		return fmt.Errorf("invalid architecture string condition val %q", archVal)
+	}
 }
 
 // validateContext ensures that the Test's Context is valid.

--- a/pkg/test/loader/schema/jsonschemas/conditions/string.schema.json
+++ b/pkg/test/loader/schema/jsonschemas/conditions/string.schema.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "conditions.string.schema.json",
+  "title": "String condition specification",
+  "description": "A string condition specification",
+  "type": ["object", "null"],
+  "properties": {
+    "op": {
+      "description": "The condition operator",
+      "type": "string",
+      "enum": [
+        "eq",
+        "ne"
+      ],
+      "examples": [
+        "eq"
+      ]
+    },
+    "val": {
+      "description": "The condition value"
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "op": {
+            "enum": ["eq", "ne"]
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "val": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  ],
+  "required": [
+    "op",
+    "val"
+  ]
+}

--- a/pkg/test/loader/schema/jsonschemas/runIf.schema.json
+++ b/pkg/test/loader/schema/jsonschemas/runIf.schema.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "runIf.schema.json",
+  "title": "Test run conditions",
+  "description": "The conditions under which the test is eligible to run. It can be used to constrain the execution to specific settings (e.g.: host architecture). If multiple conditions are specified, their logical outcomes are ANDed.",
+  "type": ["object", "null"],
+  "properties": {
+    "arch": {
+      "description": "Express a run eligibility condition related to the host architecture",
+      "$ref": "conditions.string.schema.json",
+      "properties": {
+        "val": {
+          "enum": ["amd64", "arm64"]
+        }
+      }
+    }
+  }
+}

--- a/pkg/test/loader/schema/jsonschemas/test.schema.json
+++ b/pkg/test/loader/schema/jsonschemas/test.schema.json
@@ -20,6 +20,9 @@
       "type": "string",
       "minLength": 1
     },
+    "runIf": {
+      "$ref": "runIf.schema.json"
+    },
     "runner": {
       "description": "The type of test runner",
       "type": "string",

--- a/pkg/test/loader/schema/schema.go
+++ b/pkg/test/loader/schema/schema.go
@@ -31,6 +31,10 @@ var (
 	bindingSchema string
 	//go:embed jsonschemas/test.schema.json
 	testSchema string
+	//go:embed jsonschemas/runIf.schema.json
+	runIfSchema string
+	//go:embed jsonschemas/conditions/string.schema.json
+	stringCondSchema string
 	//go:embed jsonschemas/context.schema.json
 	contextSchema string
 	//go:embed jsonschemas/resource.schema.json
@@ -119,6 +123,8 @@ var schemas = map[string]string{
 	rootSchemaURL:                           descriptionSchema,
 	bindingSchemaURL:                        bindingSchema,
 	"test.schema.json":                      testSchema,
+	"runIf.schema.json":                     runIfSchema,
+	"conditions.string.schema.json":         stringCondSchema,
 	"context.schema.json":                   contextSchema,
 	"resource.schema.json":                  resourceSchema,
 	"resources.clientServer.schema.json":    clientServerResourceSchema,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our [CONTRIBUTING.md](../CONTRIBUTING.md).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note: it's really useful for the changelog!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

/kind cleanup

> /kind documentation

> /kind tests

/kind feature

> If this PR prepares a chart release, uncomment:

> /kind chart-release

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

/area commands

/area pkg

> /area events

> /area chart

/area automation

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

This PR adds support for constraining tests execution by architecture. The user can specify a `runIf` field to require that the test is eligible for execution only under specific settings. As previously stated, the only constraint that can currently be applied is an architecture-based one. Currently, only two architecture are supported: "amd64" and "arm64". The `suite render` sub-command gained a new `--eligible` flag that changes the semantic of the tool: if provided, only eligible tests are taken into account. Notice that using `--eligible` together with `--count` results in the output of the eligible tests count: this number is what the new version of the GitHub action returns as `expected-tests`.

Specifying an eligibility condition looks like the following:
```YAML
tests:
  ...
  runIf: arch: {op: "eq", val: "amd64"}
  ...
```

Moreover, this PR fixes a small (but harmless) bug in `decodeTestStepType()`.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:
