### PR TITLE
fix(suite/loader): avoid sharing backing arrays between matrix combinations

### DIFF
--- a/pkg/test/loader/template.go
+++ b/pkg/test/loader/template.go
@@ -291,7 +291,10 @@ func combine(combValue *combinationValue, combs []combination) []combination {
 
 	newCombs := make([]combination, 0, len(combs))
 	for _, comb := range combs {
-		newComb := comb
+		// Copy rather than append to comb directly: the caller reuses combs for every value of the current key, so
+		// appending in place would let siblings share a backing array once comb has spare capacity.
+		newComb := make(combination, len(comb), len(comb)+1)
+		copy(newComb, comb)
 		newComb = append(newComb, combValue)
 		newCombs = append(newCombs, newComb)
 	}

--- a/pkg/test/loader/template_test.go
+++ b/pkg/test/loader/template_test.go
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (C) 2026 The Falco Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package loader
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// matrixTemplate is a test template whose matrix case spec has four keys of two values each, so it must expand to
+// sixteen distinct test cases.
+const matrixTemplate = `
+tests:
+  - name: matrix_template
+    description: "four-key matrix"
+    runner: HostRunner
+    steps:
+      - type: syscall
+        name: w1
+        syscall: write
+        args:
+          fd: 1
+          buffer: "%{ item.a }"
+    cases:
+      - strategy: matrix
+        values:
+          a: ["a1", "a2"]
+          b: ["b1", "b2"]
+          c: ["c1", "c2"]
+          d: ["d1", "d2"]
+`
+
+// TestMatrixCaseStrategyGeneratesDistinctCases verifies that a matrix case spec expands to the full cartesian product.
+// Combinations used to be built by appending to a slice the caller kept using, so once a combination had spare
+// capacity the siblings derived from it shared a backing array and the last value written won. The count of generated
+// tests stayed right, which is what made it quiet: sixteen tests were emitted but only eight of them differed.
+func TestMatrixCaseStrategyGeneratesDistinctCases(t *testing.T) {
+	desc, err := New(nil, nil).Load(strings.NewReader(matrixTemplate))
+	require.NoError(t, err)
+	require.Len(t, desc.Tests, 16)
+
+	seen := make(map[string]int, len(desc.Tests))
+	for _, test := range desc.Tests {
+		testCase := test.OriginatingTestCase
+		require.Len(t, testCase, 4)
+		keys := make([]string, 0, len(testCase))
+		for key := range testCase {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+
+		var sb strings.Builder
+		for _, key := range keys {
+			fmt.Fprintf(&sb, "%s=%v,", key, testCase[key])
+		}
+		seen[sb.String()]++
+	}
+
+	assert.Len(t, seen, 16, "matrix expansion produced %d distinct combinations out of 16 tests: %v", len(seen), seen)
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our [CONTRIBUTING.md](../CONTRIBUTING.md).
2. Please label this pull request according to what type of issue you are addressing.
3. Please add a release note: it's really useful for the changelog!
4. If the PR is unfinished while opening it specify a wip in the title before the actual title, for example, "wip: my awesome feature"
-->

**What type of PR is this?**

> Uncomment one (or more) `/kind <>` lines:

/kind bug

> /kind cleanup

> /kind documentation

> /kind tests

> /kind feature

> If this PR prepares a chart release, uncomment:

> /kind chart-release

<!--
Please remove the leading whitespace before the `/kind <>` you uncommented.
-->

**Any specific area of the project related to this PR?**

> Uncomment one (or more) `/area <>` lines:

> /area commands

/area pkg

> /area events

> /area chart

> /area automation

<!--
Please remove the leading whitespace before the `/area <>` you uncommented.
-->

**What this PR does / why we need it**:

`combine` derived each new combination with `newComb := comb` followed by an append. That copies the slice header only, and `generateCombinations` calls `combine` once per value of the current key while passing the same `combs` each time, so as soon as a combination carries spare capacity the siblings built from it write to the same backing array and the last value wins.

Combinations reach that state after the third key, because the append that grows them from two to three elements leaves room for a fourth. From four keys on, half of the matrix is silently lost: the number of generated tests is still right, so nothing looks wrong, but the tests are duplicates. A four-key spec with two values each expands to sixteen tests covering eight combinations, and one of the values of the last key never appears at all.

Copying the combination before appending keeps each branch independent.

**Which issue(s) this PR fixes**:

<!--
Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
If PR is `kind/failing-tests` or `kind/flaky-test`, please post the related issues/tests in a comment and do not use `Fixes`.
-->

Fixes #

**Special notes for your reviewer**:

Added `pkg/test/loader/template_test.go`, which loads a four-key matrix template through `Loader.Load` and counts distinct combinations. On main it reports 8 of 16 (with `d1` missing from every case); with the change it reports 16. The package had no tests before, so this is the first file there.

The rest of `./pkg/...` builds and tests the same before and after; the packages that fail to build here are the Linux-only syscall steps and `libcap`, which is expected on darwin.
